### PR TITLE
feat(cluster-autoscaler/exoscale): implement caching

### DIFF
--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
@@ -59,6 +59,21 @@ func (e *exoscaleCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 // should not be processed by cluster autoscaler, or non-nil error if such
 // occurred. Must be implemented.
 func (e *exoscaleCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	// Fast path: Check for nodepool-id label to avoid API calls
+	if nodepoolID, hasLabel := node.Labels["node.exoscale.net/nodepool-id"]; hasLabel {
+		// Try to find existing nodegroup with this SKS nodepool ID
+		for _, ng := range e.manager.nodeGroups {
+			// Check if this is an SKS nodepool nodegroup
+			if sksNG, ok := ng.(*sksNodepoolNodeGroup); ok {
+				if *sksNG.sksNodepool.ID == nodepoolID {
+					debugf("found SKS nodegroup %s for node %s using nodepool-id label", nodepoolID, node.Name)
+					return ng, nil
+				}
+			}
+		}
+		debugf("nodepool-id label found (%s) but no matching SKS nodegroup, falling back to API lookup", nodepoolID)
+	}
+
 	instancePool, err := e.instancePoolFromNode(node)
 	if err != nil {
 		if err == errNoInstancePool {
@@ -77,7 +92,7 @@ func (e *exoscaleCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovide
 			sksNodepool *egoscale.SKSNodepool
 		)
 
-		sksClusters, err := e.manager.client.ListSKSClusters(e.manager.ctx, e.manager.zone)
+		sksClusters, err := e.manager.ListSKSClustersCached(e.manager.ctx, e.manager.zone)
 		if err != nil {
 			errorf("unable to list SKS clusters: %v", err)
 			return nil, err
@@ -264,7 +279,7 @@ func (e *exoscaleCloudProvider) instancePoolFromNode(node *apiv1.Node) (*egoscal
 
 	debugf("looking up node group for node ID %s", nodeID)
 
-	instance, err := e.manager.client.GetInstance(e.manager.ctx, e.manager.zone, nodeID)
+	instance, err := e.manager.GetInstanceCached(e.manager.ctx, e.manager.zone, nodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -273,5 +288,5 @@ func (e *exoscaleCloudProvider) instancePoolFromNode(node *apiv1.Node) (*egoscal
 		return nil, errNoInstancePool
 	}
 
-	return e.manager.client.GetInstancePool(e.manager.ctx, e.manager.zone, instance.Manager.ID)
+	return e.manager.GetInstancePoolCached(e.manager.ctx, e.manager.zone, instance.Manager.ID)
 }

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_manager.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_manager.go
@@ -20,7 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
+	"sync"
+	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	egoscale "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2"
@@ -38,7 +41,78 @@ type exoscaleClient interface {
 	ScaleSKSNodepool(context.Context, string, *egoscale.SKSCluster, *egoscale.SKSNodepool, int64) error
 }
 
-const defaultAPIEnvironment = "api"
+const (
+	defaultAPIEnvironment = "api"
+	// Cache instances for 5 minutes to reduce API calls
+	instanceCacheTTL = 5 * time.Minute
+	// Cache quota for 1 hour since it rarely changes
+	quotaCacheTTL = 1 * time.Hour
+	// Cache SKS clusters for 10 minutes since they rarely change
+	sksClustersCacheTTL = 10 * time.Minute
+	// Cache instance pools for 5 minutes since they change less frequently than instances
+	instancePoolCacheTTL = 5 * time.Minute
+
+	// Jitter constants (as percentage of TTL)
+	jitterMinPercent = 5  // 5% of TTL
+	jitterMaxPercent = 20 // 20% of TTL
+)
+
+// Generic cache entry interface for consolidating cache operations
+type cacheEntry interface {
+	isExpired(now time.Time) bool
+}
+
+// Generic cache operations to reduce code duplication
+func clearExpiredMapEntries[K comparable, V cacheEntry](cache map[K]V, mutex *sync.RWMutex) {
+	now := time.Now()
+	mutex.Lock()
+	defer mutex.Unlock()
+	for key, entry := range cache {
+		if entry.isExpired(now) {
+			delete(cache, key)
+		}
+	}
+}
+
+// instanceCacheEntry represents a cached instance with its expiration time
+type instanceCacheEntry struct {
+	instance  *egoscale.Instance
+	expiredAt time.Time
+}
+
+func (e *instanceCacheEntry) isExpired(now time.Time) bool {
+	return now.After(e.expiredAt)
+}
+
+// quotaCacheEntry represents a cached quota with its expiration time
+type quotaCacheEntry struct {
+	quota     int
+	expiredAt time.Time
+}
+
+func (e *quotaCacheEntry) isExpired(now time.Time) bool {
+	return now.After(e.expiredAt)
+}
+
+// sksClustersCacheEntry represents cached SKS clusters with expiration time
+type sksClustersCacheEntry struct {
+	clusters  []*egoscale.SKSCluster
+	expiredAt time.Time
+}
+
+func (e *sksClustersCacheEntry) isExpired(now time.Time) bool {
+	return now.After(e.expiredAt)
+}
+
+// instancePoolCacheEntry represents a cached instance pool with its expiration time
+type instancePoolCacheEntry struct {
+	instancePool *egoscale.InstancePool
+	expiredAt    time.Time
+}
+
+func (e *instancePoolCacheEntry) isExpired(now time.Time) bool {
+	return now.After(e.expiredAt)
+}
 
 // Manager handles Exoscale communication and data caching of
 // node groups (Instance Pools).
@@ -48,6 +122,22 @@ type Manager struct {
 	zone          string
 	nodeGroups    []cloudprovider.NodeGroup
 	discoveryOpts cloudprovider.NodeGroupDiscoveryOptions
+
+	// Instance cache to reduce API calls
+	instanceCache   map[string]*instanceCacheEntry
+	instanceCacheMu sync.RWMutex
+
+	// Quota cache to reduce API calls
+	quotaCache   *quotaCacheEntry
+	quotaCacheMu sync.RWMutex
+
+	// SKS clusters cache to reduce API calls
+	sksClustersCache   *sksClustersCacheEntry
+	sksClustersCacheMu sync.RWMutex
+
+	// Instance pool cache to reduce API calls
+	instancePoolCache   map[string]*instancePoolCacheEntry
+	instancePoolCacheMu sync.RWMutex
 }
 
 func newManager(discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*Manager, error) {
@@ -83,10 +173,12 @@ func newManager(discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*Manager
 	debugf("initializing manager with zone=%s environment=%s", zone, apiEnvironment)
 
 	m := &Manager{
-		ctx:           exoapi.WithEndpoint(context.Background(), exoapi.NewReqEndpoint(apiEnvironment, zone)),
-		client:        client,
-		zone:          zone,
-		discoveryOpts: discoveryOpts,
+		ctx:               exoapi.WithEndpoint(context.Background(), exoapi.NewReqEndpoint(apiEnvironment, zone)),
+		client:            client,
+		zone:              zone,
+		discoveryOpts:     discoveryOpts,
+		instanceCache:     make(map[string]*instanceCacheEntry),
+		instancePoolCache: make(map[string]*instancePoolCacheEntry),
 	}
 
 	return m, nil
@@ -95,9 +187,15 @@ func newManager(discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*Manager
 // Refresh refreshes the cache holding the node groups. This is called by the CA
 // based on the `--scan-interval`. By default it's 10 seconds.
 func (m *Manager) Refresh() error {
+	// Clean up expired cache entries
+	m.ClearExpiredInstanceCache()
+	m.ClearExpiredQuotaCache()
+	m.ClearExpiredSKSClustersCache()
+	m.ClearExpiredInstancePoolCache()
+
 	var nodeGroups []cloudprovider.NodeGroup
 	for _, ng := range m.nodeGroups {
-		if _, err := m.client.GetInstancePool(m.ctx, m.zone, ng.Id()); err != nil {
+		if _, err := m.GetInstancePoolCached(m.ctx, m.zone, ng.Id()); err != nil {
 			if errors.Is(err, exoapi.ErrNotFound) {
 				debugf("removing node group %s from manager cache", ng.Id())
 				continue
@@ -117,11 +215,344 @@ func (m *Manager) Refresh() error {
 	return nil
 }
 
+// addJitter adds random jitter to TTL to prevent thundering herd.
+// Jitter is between 5% and 20% of the original TTL.
+func (m *Manager) addJitter(ttl time.Duration) time.Duration {
+	minJitter := int64(float64(ttl.Nanoseconds()) * jitterMinPercent / 100)
+	maxJitter := int64(float64(ttl.Nanoseconds()) * jitterMaxPercent / 100)
+	jitter := time.Duration(rand.Int63n(maxJitter-minJitter) + minJitter)
+	return ttl + jitter
+}
+
+// logCacheHit logs when a cache entry is found and returned
+func (m *Manager) logCacheHit(cacheType, identifier string) {
+	debugf("returning cached %s %s", cacheType, identifier)
+}
+
+// logCacheMiss logs when a cache miss occurs and API call is needed
+func (m *Manager) logCacheMiss(cacheType, identifier string) {
+	debugf("fetching %s %s from API", cacheType, identifier)
+}
+
+// invalidateCacheEntry is a generic helper for cache invalidation with logging
+func (m *Manager) invalidateCacheEntry(cacheType, identifier string) {
+	debugf("invalidating %s cache for %s", cacheType, identifier)
+}
+
 func (m *Manager) computeInstanceQuota() (int, error) {
+	now := time.Now()
+
+	// Check cache first
+	m.quotaCacheMu.RLock()
+	if m.quotaCache != nil && now.Before(m.quotaCache.expiredAt) {
+		cachedQuota := m.quotaCache.quota
+		m.quotaCacheMu.RUnlock()
+		debugf("cache hit: returning cached instance quota %d", cachedQuota)
+		return cachedQuota, nil
+	}
+	m.quotaCacheMu.RUnlock()
+
+	// Cache miss or expired, fetch from API
+	m.logCacheMiss("instance", "quota")
 	instanceQuota, err := m.client.GetQuota(m.ctx, m.zone, "instance")
 	if err != nil {
 		return 0, fmt.Errorf("unable to retrieve Compute instances quota: %v", err)
 	}
 
-	return int(*instanceQuota.Limit), nil
+	quotaValue := int(*instanceQuota.Limit)
+
+	// Cache the result
+	m.quotaCacheMu.Lock()
+	m.quotaCache = &quotaCacheEntry{
+		quota:     quotaValue,
+		expiredAt: now.Add(m.addJitter(quotaCacheTTL)),
+	}
+	m.quotaCacheMu.Unlock()
+
+	return quotaValue, nil
+}
+
+// GetInstanceCached retrieves an instance from cache if available and not expired,
+// otherwise fetches it from the API and caches it.
+func (m *Manager) GetInstanceCached(ctx context.Context, zone, instanceID string) (*egoscale.Instance, error) {
+	now := time.Now()
+
+	// Check cache first
+	m.instanceCacheMu.RLock()
+	if entry, exists := m.instanceCache[instanceID]; exists && !entry.isExpired(now) {
+		m.instanceCacheMu.RUnlock()
+		m.logCacheHit("instance", instanceID)
+		return entry.instance, nil
+	}
+	m.instanceCacheMu.RUnlock()
+
+	// Cache miss or expired, fetch from API
+	m.logCacheMiss("instance", instanceID)
+	instance, err := m.client.GetInstance(ctx, zone, instanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result
+	ttlWithJitter := m.addJitter(instanceCacheTTL)
+	m.instanceCacheMu.Lock()
+	m.instanceCache[instanceID] = &instanceCacheEntry{
+		instance:  instance,
+		expiredAt: now.Add(ttlWithJitter),
+	}
+	m.instanceCacheMu.Unlock()
+	debugf("cached instance %s for %v (with jitter)", instanceID, ttlWithJitter)
+
+	return instance, nil
+}
+
+// GetInstancesCached retrieves multiple instances efficiently, using cache when possible.
+// This is optimized for batch operations where we know all instances belong to the same nodepool.
+func (m *Manager) GetInstancesCached(ctx context.Context, zone string, instanceIDs []string) ([]*egoscale.Instance, error) {
+	now := time.Now()
+	instances := make([]*egoscale.Instance, len(instanceIDs))
+	var missingIDs []string
+	var missingIndices []int
+
+	// First pass: collect cached instances and identify missing ones
+	m.instanceCacheMu.RLock()
+	for i, instanceID := range instanceIDs {
+		if entry, exists := m.instanceCache[instanceID]; exists && now.Before(entry.expiredAt) {
+			instances[i] = entry.instance
+			m.logCacheHit("instance", instanceID)
+		} else {
+			missingIDs = append(missingIDs, instanceID)
+			missingIndices = append(missingIndices, i)
+		}
+	}
+	m.instanceCacheMu.RUnlock()
+
+	// Second pass: fetch missing instances from API
+	if len(missingIDs) > 0 {
+		m.logCacheMiss("instances", fmt.Sprintf("%d instances: %v", len(missingIDs), missingIDs))
+
+		// Fetch missing instances concurrently for better performance
+		type fetchResult struct {
+			index    int
+			instance *egoscale.Instance
+			err      error
+		}
+
+		results := make(chan fetchResult, len(missingIDs))
+
+		for i, instanceID := range missingIDs {
+			go func(idx int, id string) {
+				instance, err := m.client.GetInstance(ctx, zone, id)
+				results <- fetchResult{index: idx, instance: instance, err: err}
+			}(i, instanceID)
+		}
+
+		// Collect results and cache them
+		for i := 0; i < len(missingIDs); i++ {
+			result := <-results
+			if result.err != nil {
+				return nil, result.err
+			}
+
+			originalIndex := missingIndices[result.index]
+			instances[originalIndex] = result.instance
+
+			// Cache the result
+			ttlWithJitter := m.addJitter(instanceCacheTTL)
+			instanceID := missingIDs[result.index]
+			m.instanceCacheMu.Lock()
+			m.instanceCache[instanceID] = &instanceCacheEntry{
+				instance:  result.instance,
+				expiredAt: now.Add(ttlWithJitter),
+			}
+			m.instanceCacheMu.Unlock()
+			debugf("cached instance %s for %v (batch operation)", instanceID, ttlWithJitter)
+		}
+	}
+
+	return instances, nil
+}
+
+// InvalidateInstanceCache removes an instance from the cache.
+// This should be called when an instance is known to have changed (e.g., after scaling operations).
+func (m *Manager) InvalidateInstanceCache(instanceID string) {
+	m.instanceCacheMu.Lock()
+	delete(m.instanceCache, instanceID)
+	m.instanceCacheMu.Unlock()
+	debugf("invalidated cache for instance %s", instanceID)
+}
+
+// InvalidateInstanceCacheMultiple removes multiple instances from the cache.
+func (m *Manager) InvalidateInstanceCacheMultiple(instanceIDs []string) {
+	m.instanceCacheMu.Lock()
+	for _, instanceID := range instanceIDs {
+		delete(m.instanceCache, instanceID)
+	}
+	m.instanceCacheMu.Unlock()
+	debugf("invalidated cache for instances %v", instanceIDs)
+}
+
+// InvalidateInstancePoolCache removes all instances from the cache that belong to the given instance pool
+func (m *Manager) InvalidateInstancePoolCache(instancePool *egoscale.InstancePool) {
+	if instancePool == nil || instancePool.ID == nil {
+		return
+	}
+
+	poolID := *instancePool.ID
+
+	// We need to get the instances in this pool to invalidate their cache entries
+	// Since we can't directly access the instances from the pool, we'll just invalidate by pool ID
+	m.instancePoolCacheMu.Lock()
+	delete(m.instancePoolCache, poolID)
+	m.instancePoolCacheMu.Unlock()
+
+	// Also try to invalidate any cached instances that might belong to this pool
+	// We'll need to check each cached instance to see if it belongs to this pool
+	m.instanceCacheMu.Lock()
+	for instanceID, entry := range m.instanceCache {
+		if entry.instance.Manager != nil && entry.instance.Manager.ID == poolID {
+			delete(m.instanceCache, instanceID)
+		}
+	}
+	m.instanceCacheMu.Unlock()
+}
+
+// ClearExpiredInstanceCache removes expired entries from the cache.
+// This is called during Refresh to prevent unbounded cache growth.
+func (m *Manager) ClearExpiredInstanceCache() {
+	m.instanceCacheMu.RLock()
+	initialCount := len(m.instanceCache)
+	m.instanceCacheMu.RUnlock()
+
+	clearExpiredMapEntries(m.instanceCache, &m.instanceCacheMu)
+
+	m.instanceCacheMu.RLock()
+	finalCount := len(m.instanceCache)
+	m.instanceCacheMu.RUnlock()
+
+	if removed := initialCount - finalCount; removed > 0 {
+		debugf("cleared %d expired instance cache entries (%d remaining)", removed, finalCount)
+	}
+}
+
+// ClearExpiredQuotaCache removes expired quota cache entry.
+// This is called during Refresh to prevent stale quota data.
+func (m *Manager) ClearExpiredQuotaCache() {
+	now := time.Now()
+	m.quotaCacheMu.Lock()
+	if m.quotaCache != nil && now.After(m.quotaCache.expiredAt) {
+		m.quotaCache = nil
+		debugf("cleared expired quota cache")
+	}
+	m.quotaCacheMu.Unlock()
+}
+
+// InvalidateQuotaCache removes the quota from the cache.
+// This can be called if the quota is known to have changed.
+func (m *Manager) InvalidateQuotaCache() {
+	m.quotaCacheMu.Lock()
+	m.quotaCache = nil
+	m.quotaCacheMu.Unlock()
+	debugf("invalidated quota cache")
+}
+
+// ListSKSClustersCached retrieves SKS clusters from cache if available and not expired,
+// otherwise fetches them from the API and caches them.
+func (m *Manager) ListSKSClustersCached(ctx context.Context, zone string) ([]*egoscale.SKSCluster, error) {
+	now := time.Now()
+
+	// Check cache first
+	m.sksClustersCacheMu.RLock()
+	if m.sksClustersCache != nil && now.Before(m.sksClustersCache.expiredAt) {
+		cachedClusters := m.sksClustersCache.clusters
+		m.sksClustersCacheMu.RUnlock()
+		m.logCacheHit("SKS clusters", fmt.Sprintf("(%d clusters)", len(cachedClusters)))
+		return cachedClusters, nil
+	}
+	m.sksClustersCacheMu.RUnlock()
+
+	// Cache miss or expired, fetch from API
+	m.logCacheMiss("SKS", "clusters")
+	clusters, err := m.client.ListSKSClusters(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result
+	m.sksClustersCacheMu.Lock()
+	m.sksClustersCache = &sksClustersCacheEntry{
+		clusters:  clusters,
+		expiredAt: now.Add(m.addJitter(sksClustersCacheTTL)),
+	}
+	m.sksClustersCacheMu.Unlock()
+
+	return clusters, nil
+}
+
+// InvalidateSKSClustersCache removes the SKS clusters from the cache.
+// This can be called if the clusters are known to have changed.
+func (m *Manager) InvalidateSKSClustersCache() {
+	m.sksClustersCacheMu.Lock()
+	m.sksClustersCache = nil
+	m.sksClustersCacheMu.Unlock()
+	debugf("invalidated SKS clusters cache")
+}
+
+// ClearExpiredSKSClustersCache removes expired SKS clusters cache entry.
+// This is called during Refresh to prevent stale cluster data.
+func (m *Manager) ClearExpiredSKSClustersCache() {
+	now := time.Now()
+	m.sksClustersCacheMu.Lock()
+	if m.sksClustersCache != nil && now.After(m.sksClustersCache.expiredAt) {
+		m.sksClustersCache = nil
+		debugf("cleared expired SKS clusters cache")
+	}
+	m.sksClustersCacheMu.Unlock()
+}
+
+// GetInstancePoolCached retrieves an instance pool from cache if available and not expired,
+// otherwise fetches it from the API and caches it.
+func (m *Manager) GetInstancePoolCached(ctx context.Context, zone, instancePoolID string) (*egoscale.InstancePool, error) {
+	now := time.Now()
+
+	// Check cache first
+	m.instancePoolCacheMu.RLock()
+	if entry, exists := m.instancePoolCache[instancePoolID]; exists && !entry.isExpired(now) {
+		m.instancePoolCacheMu.RUnlock()
+		m.logCacheHit("instance pool", instancePoolID)
+		return entry.instancePool, nil
+	}
+	m.instancePoolCacheMu.RUnlock()
+
+	// Cache miss or expired, fetch from API
+	m.logCacheMiss("instance pool", instancePoolID)
+	instancePool, err := m.client.GetInstancePool(ctx, zone, instancePoolID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result
+	m.instancePoolCacheMu.Lock()
+	m.instancePoolCache[instancePoolID] = &instancePoolCacheEntry{
+		instancePool: instancePool,
+		expiredAt:    now.Add(m.addJitter(instancePoolCacheTTL)),
+	}
+	m.instancePoolCacheMu.Unlock()
+
+	return instancePool, nil
+}
+
+// InvalidateInstancePoolCacheByID removes an instance pool from the cache by ID.
+// This should be called when an instance pool is known to have changed.
+func (m *Manager) InvalidateInstancePoolCacheByID(instancePoolID string) {
+	m.instancePoolCacheMu.Lock()
+	delete(m.instancePoolCache, instancePoolID)
+	m.instancePoolCacheMu.Unlock()
+	debugf("invalidated cache for instance pool %s", instancePoolID)
+}
+
+// ClearExpiredInstancePoolCache removes expired entries from the instance pool cache.
+// This is called during Refresh to prevent unbounded cache growth.
+func (m *Manager) ClearExpiredInstancePoolCache() {
+	clearExpiredMapEntries(m.instancePoolCache, &m.instancePoolCacheMu)
 }

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_manager_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_manager_cache_test.go
@@ -1,0 +1,684 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exoscale
+
+import (
+	"sync"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	egoscale "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2"
+)
+
+// Test helper functions to reduce duplication
+
+// createMockInstance creates a standard mock instance for testing
+func createMockInstance(id, name string) *egoscale.Instance {
+	return &egoscale.Instance{
+		ID:   &id,
+		Name: &name,
+		Manager: &egoscale.InstanceManager{
+			ID:   testInstancePoolID,
+			Type: "instance-pool",
+		},
+		State: &testInstanceState,
+	}
+}
+
+// createMockInstancePool creates a standard mock instance pool for testing
+func createMockInstancePool(id, name string) *egoscale.InstancePool {
+	return &egoscale.InstancePool{
+		ID:   &id,
+		Name: &name,
+		Size: &testInstancePoolSize,
+	}
+}
+
+// createMockSKSCluster creates a standard mock SKS cluster for testing
+func createMockSKSCluster(id, name string) *egoscale.SKSCluster {
+	return &egoscale.SKSCluster{
+		ID:   &id,
+		Name: &name,
+		Zone: &testZone,
+	}
+}
+
+// setupInstanceAPICall sets up a mock API call expectation for GetInstance
+func (ts *cloudProviderTestSuite) setupInstanceAPICall(instanceID string, mockInstance *egoscale.Instance) {
+	ts.p.manager.client.(*exoscaleClientMock).
+		On("GetInstance", ts.p.manager.ctx, ts.p.manager.zone, instanceID).
+		Return(mockInstance, nil).Once()
+}
+
+// setupInstancePoolAPICall sets up a mock API call expectation for GetInstancePool
+func (ts *cloudProviderTestSuite) setupInstancePoolAPICall(instancePoolID string, mockInstancePool *egoscale.InstancePool) {
+	ts.p.manager.client.(*exoscaleClientMock).
+		On("GetInstancePool", ts.p.manager.ctx, ts.p.manager.zone, instancePoolID).
+		Return(mockInstancePool, nil).Once()
+}
+
+// Advanced test helper functions to eliminate duplication
+
+// setupInstanceCacheEntry manually adds an instance to cache with specified TTL
+func (ts *cloudProviderTestSuite) setupInstanceCacheEntry(instanceID string, instance *egoscale.Instance, ttl time.Duration) {
+	ts.p.manager.instanceCacheMu.Lock()
+	defer ts.p.manager.instanceCacheMu.Unlock()
+	ts.p.manager.instanceCache[instanceID] = &instanceCacheEntry{
+		instance:  instance,
+		expiredAt: time.Now().Add(ttl),
+	}
+}
+
+// setupInstancePoolCacheEntry manually adds an instance pool to cache with specified TTL
+func (ts *cloudProviderTestSuite) setupInstancePoolCacheEntry(poolID string, pool *egoscale.InstancePool, ttl time.Duration) {
+	ts.p.manager.instancePoolCacheMu.Lock()
+	defer ts.p.manager.instancePoolCacheMu.Unlock()
+	ts.p.manager.instancePoolCache[poolID] = &instancePoolCacheEntry{
+		instancePool: pool,
+		expiredAt:    time.Now().Add(ttl),
+	}
+}
+
+// setupQuotaCacheEntry manually adds a quota to cache with specified TTL
+func (ts *cloudProviderTestSuite) setupQuotaCacheEntry(quota int, ttl time.Duration) {
+	ts.p.manager.quotaCacheMu.Lock()
+	defer ts.p.manager.quotaCacheMu.Unlock()
+	ts.p.manager.quotaCache = &quotaCacheEntry{
+		quota:     quota,
+		expiredAt: time.Now().Add(ttl),
+	}
+}
+
+// verifyInstanceCacheExists checks if an instance exists in cache
+func (ts *cloudProviderTestSuite) verifyInstanceCacheExists(instanceID string, shouldExist bool) {
+	ts.p.manager.instanceCacheMu.RLock()
+	defer ts.p.manager.instanceCacheMu.RUnlock()
+	_, exists := ts.p.manager.instanceCache[instanceID]
+	ts.Require().Equal(shouldExist, exists)
+}
+
+// verifyInstancePoolCacheExists checks if an instance pool exists in cache
+func (ts *cloudProviderTestSuite) verifyInstancePoolCacheExists(poolID string, shouldExist bool) {
+	ts.p.manager.instancePoolCacheMu.RLock()
+	defer ts.p.manager.instancePoolCacheMu.RUnlock()
+	_, exists := ts.p.manager.instancePoolCache[poolID]
+	ts.Require().Equal(shouldExist, exists)
+}
+
+// verifyQuotaCacheExists checks if quota exists in cache
+func (ts *cloudProviderTestSuite) verifyQuotaCacheExists(shouldExist bool) {
+	ts.p.manager.quotaCacheMu.RLock()
+	defer ts.p.manager.quotaCacheMu.RUnlock()
+	exists := ts.p.manager.quotaCache != nil
+	ts.Require().Equal(shouldExist, exists)
+}
+
+// assertMockExpectations is a helper to assert all mock expectations
+func (ts *cloudProviderTestSuite) assertMockExpectations() {
+	ts.p.manager.client.(*exoscaleClientMock).AssertExpectations(ts.T())
+}
+
+// testCacheMissHitPattern tests the common cache miss -> cache hit pattern
+func (ts *cloudProviderTestSuite) testInstanceCacheMissHitPattern(instanceID string, mockInstance *egoscale.Instance) {
+	// Test cache miss - should call API
+	ts.setupInstanceAPICall(instanceID, mockInstance)
+
+	instance1, err := ts.p.manager.GetInstanceCached(ts.p.manager.ctx, ts.p.manager.zone, instanceID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(mockInstance, instance1)
+
+	// Test cache hit - should NOT call API
+	instance2, err := ts.p.manager.GetInstanceCached(ts.p.manager.ctx, ts.p.manager.zone, instanceID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(mockInstance, instance2)
+
+	ts.assertMockExpectations()
+}
+
+// testInstancePoolCacheMissHitPattern tests the common cache miss -> cache hit pattern for instance pools
+func (ts *cloudProviderTestSuite) testInstancePoolCacheMissHitPattern(poolID string, mockPool *egoscale.InstancePool) {
+	// Test cache miss - should call API
+	ts.setupInstancePoolAPICall(poolID, mockPool)
+
+	pool1, err := ts.p.manager.GetInstancePoolCached(ts.p.manager.ctx, ts.p.manager.zone, poolID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(mockPool, pool1)
+
+	// Test cache hit - should NOT call API
+	pool2, err := ts.p.manager.GetInstancePoolCached(ts.p.manager.ctx, ts.p.manager.zone, poolID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(mockPool, pool2)
+
+	ts.assertMockExpectations()
+}
+
+func (ts *cloudProviderTestSuite) TestGetInstanceCached() {
+	mockInstance := createMockInstance(testInstanceID, testInstanceName)
+	ts.testInstanceCacheMissHitPattern(testInstanceID, mockInstance)
+}
+
+func (ts *cloudProviderTestSuite) TestGetInstancesCachedBatch() {
+	instance1ID := testInstanceID
+	instance2ID := testInstancePoolID // Reuse as second instance ID for simplicity
+
+	mockInstance1 := createMockInstance(instance1ID, testInstanceName)
+	mockInstance2 := createMockInstance(instance2ID, testInstancePoolName)
+
+	// Both instances should be fetched from API (cache miss)
+	ts.setupInstanceAPICall(instance1ID, mockInstance1)
+	ts.setupInstanceAPICall(instance2ID, mockInstance2)
+
+	instances, err := ts.p.manager.GetInstancesCached(ts.p.manager.ctx, ts.p.manager.zone, []string{instance1ID, instance2ID})
+	ts.Require().NoError(err)
+	ts.Require().Len(instances, 2)
+	ts.Require().Equal(mockInstance1, instances[0])
+	ts.Require().Equal(mockInstance2, instances[1])
+
+	// Second call should use cache (no additional API calls)
+	instances2, err := ts.p.manager.GetInstancesCached(ts.p.manager.ctx, ts.p.manager.zone, []string{instance1ID, instance2ID})
+	ts.Require().NoError(err)
+	ts.Require().Len(instances2, 2)
+	ts.Require().Equal(mockInstance1, instances2[0])
+	ts.Require().Equal(mockInstance2, instances2[1])
+
+	ts.assertMockExpectations()
+}
+
+func (ts *cloudProviderTestSuite) TestGetInstancesCachedPartialCache() {
+	instance1ID := testInstanceID
+	instance2ID := testInstancePoolID // Reuse as second instance ID
+
+	mockInstance1 := &egoscale.Instance{
+		ID:    &instance1ID,
+		Name:  &testInstanceName,
+		State: &testInstanceState,
+	}
+
+	mockInstance2 := &egoscale.Instance{
+		ID:    &instance2ID,
+		Name:  &testInstancePoolName,
+		State: &testInstanceState,
+	}
+
+	// Pre-populate cache with first instance
+	ts.p.manager.instanceCacheMu.Lock()
+	ts.p.manager.instanceCache[instance1ID] = &instanceCacheEntry{
+		instance:  mockInstance1,
+		expiredAt: time.Now().Add(5 * time.Minute),
+	}
+	ts.p.manager.instanceCacheMu.Unlock()
+
+	// Only second instance should be fetched from API
+	ts.p.manager.client.(*exoscaleClientMock).
+		On("GetInstance", ts.p.manager.ctx, ts.p.manager.zone, instance2ID).
+		Return(mockInstance2, nil).Once()
+
+	instances, err := ts.p.manager.GetInstancesCached(ts.p.manager.ctx, ts.p.manager.zone, []string{instance1ID, instance2ID})
+	ts.Require().NoError(err)
+	ts.Require().Len(instances, 2)
+	ts.Require().Equal(mockInstance1, instances[0])
+	ts.Require().Equal(mockInstance2, instances[1])
+
+	ts.p.manager.client.(*exoscaleClientMock).AssertExpectations(ts.T())
+}
+
+func (ts *cloudProviderTestSuite) TestNodeGroupForNodeWithSKSNodepoolLabel() {
+	// Create a mock SKS nodepool nodegroup
+	sksNodepool := &egoscale.SKSNodepool{
+		ID:             &testSKSNodepoolID,
+		InstancePoolID: &testInstancePoolID,
+		Name:           &testSKSNodepoolName,
+		Size:           &testSKSNodepoolSize,
+	}
+
+	sksCluster := &egoscale.SKSCluster{
+		ID:   &testSKSClusterID,
+		Name: &testSKSClusterName,
+	}
+
+	nodeGroup := &sksNodepoolNodeGroup{
+		sksNodepool: sksNodepool,
+		sksCluster:  sksCluster,
+		m:           ts.p.manager,
+		minSize:     1,
+		maxSize:     10,
+	}
+
+	// Add the nodegroup to manager's nodeGroups list
+	ts.p.manager.nodeGroups = append(ts.p.manager.nodeGroups, nodeGroup)
+
+	// Create a node with the nodepool-id label set to the SKS nodepool ID
+	node := &apiv1.Node{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-node",
+			Labels: map[string]string{
+				"node.exoscale.net/nodepool-id": testSKSNodepoolID, // SKS nodepool ID, not instance pool ID
+			},
+		},
+		Spec: apiv1.NodeSpec{
+			ProviderID: "exoscale://" + testInstanceID,
+		},
+	}
+
+	// This should use the fast path and NOT make any API calls
+	foundNodeGroup, err := ts.p.NodeGroupForNode(node)
+	ts.Require().NoError(err)
+	ts.Require().Equal(nodeGroup, foundNodeGroup)
+
+	// Verify no API calls were made (fast path was used)
+	ts.p.manager.client.(*exoscaleClientMock).AssertNotCalled(ts.T(), "GetInstance")
+	ts.p.manager.client.(*exoscaleClientMock).AssertNotCalled(ts.T(), "GetInstancePool")
+	ts.p.manager.client.(*exoscaleClientMock).AssertNotCalled(ts.T(), "ListSKSClusters")
+}
+
+func (ts *cloudProviderTestSuite) TestGetInstanceCachedExpiration() {
+	mockInstance := createMockInstance(testInstanceID, testInstanceName)
+
+	// Manually set a cache entry that's already expired
+	ts.setupInstanceCacheEntry(testInstanceID, mockInstance, -1*time.Minute) // Already expired
+
+	// This should trigger API call because cache entry is expired
+	ts.setupInstanceAPICall(testInstanceID, mockInstance)
+
+	instance, err := ts.p.manager.GetInstanceCached(ts.p.manager.ctx, ts.p.manager.zone, testInstanceID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(mockInstance, instance)
+
+	ts.assertMockExpectations()
+}
+
+func (ts *cloudProviderTestSuite) TestInstanceCacheInvalidation() {
+	mockInstance := createMockInstance(testInstanceID, testInstanceName)
+
+	// Add entry to cache and verify it exists
+	ts.setupInstanceCacheEntry(testInstanceID, mockInstance, 5*time.Minute)
+	ts.verifyInstanceCacheExists(testInstanceID, true)
+
+	// Invalidate cache and verify entry is removed
+	ts.p.manager.InvalidateInstanceCache(testInstanceID)
+	ts.verifyInstanceCacheExists(testInstanceID, false)
+}
+
+func (ts *cloudProviderTestSuite) TestInstanceCacheMultipleInvalidation() {
+	mockInstance1 := &egoscale.Instance{ID: &testInstanceID}
+	mockInstance2 := &egoscale.Instance{ID: &testInstancePoolID} // Reuse as second ID
+
+	// Add entries to cache
+	ts.p.manager.instanceCacheMu.Lock()
+	ts.p.manager.instanceCache[testInstanceID] = &instanceCacheEntry{
+		instance:  mockInstance1,
+		expiredAt: time.Now().Add(5 * time.Minute),
+	}
+	ts.p.manager.instanceCache[testInstancePoolID] = &instanceCacheEntry{
+		instance:  mockInstance2,
+		expiredAt: time.Now().Add(5 * time.Minute),
+	}
+	ts.p.manager.instanceCacheMu.Unlock()
+
+	// Invalidate multiple
+	ts.p.manager.InvalidateInstanceCacheMultiple([]string{testInstanceID, testInstancePoolID})
+
+	// Verify both entries are removed
+	ts.p.manager.instanceCacheMu.RLock()
+	ts.Require().Empty(ts.p.manager.instanceCache)
+	ts.p.manager.instanceCacheMu.RUnlock()
+}
+
+func (ts *cloudProviderTestSuite) TestQuotaCaching() {
+	mockQuota := &egoscale.Quota{
+		Resource: &testComputeInstanceQuotaName,
+		Usage:    &testComputeInstanceQuotaUsage,
+		Limit:    &testComputeInstanceQuotaLimit,
+	}
+
+	// Test cache miss - should call API
+	ts.p.manager.client.(*exoscaleClientMock).
+		On("GetQuota", ts.p.manager.ctx, ts.p.manager.zone, "instance").
+		Return(mockQuota, nil).Once()
+
+	quota1, err := ts.p.manager.computeInstanceQuota()
+	ts.Require().NoError(err)
+	ts.Require().Equal(int(testComputeInstanceQuotaLimit), quota1)
+
+	// Test cache hit - should NOT call API
+	quota2, err := ts.p.manager.computeInstanceQuota()
+	ts.Require().NoError(err)
+	ts.Require().Equal(int(testComputeInstanceQuotaLimit), quota2)
+
+	ts.assertMockExpectations()
+}
+
+func (ts *cloudProviderTestSuite) TestQuotaCacheInvalidation() {
+	// Set up cache entry
+	ts.p.manager.quotaCacheMu.Lock()
+	ts.p.manager.quotaCache = &quotaCacheEntry{
+		quota:     int(testComputeInstanceQuotaLimit),
+		expiredAt: time.Now().Add(5 * time.Minute),
+	}
+	ts.p.manager.quotaCacheMu.Unlock()
+
+	// Verify cache exists
+	ts.p.manager.quotaCacheMu.RLock()
+	ts.Require().NotNil(ts.p.manager.quotaCache)
+	ts.p.manager.quotaCacheMu.RUnlock()
+
+	// Invalidate
+	ts.p.manager.InvalidateQuotaCache()
+
+	// Verify cache is cleared
+	ts.p.manager.quotaCacheMu.RLock()
+	ts.Require().Nil(ts.p.manager.quotaCache)
+	ts.p.manager.quotaCacheMu.RUnlock()
+}
+
+func (ts *cloudProviderTestSuite) TestSKSClustersCaching() {
+	mockClusters := []*egoscale.SKSCluster{
+		{
+			ID:   &testSKSClusterID,
+			Name: &testSKSClusterName,
+		},
+	}
+
+	// Test cache miss - should call API
+	ts.p.manager.client.(*exoscaleClientMock).
+		On("ListSKSClusters", ts.p.manager.ctx, ts.p.manager.zone).
+		Return(mockClusters, nil).Once()
+
+	clusters1, err := ts.p.manager.ListSKSClustersCached(ts.p.manager.ctx, ts.p.manager.zone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(mockClusters, clusters1)
+
+	// Test cache hit - should NOT call API
+	clusters2, err := ts.p.manager.ListSKSClustersCached(ts.p.manager.ctx, ts.p.manager.zone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(mockClusters, clusters2)
+
+	ts.p.manager.client.(*exoscaleClientMock).AssertExpectations(ts.T())
+}
+
+func (ts *cloudProviderTestSuite) TestSKSClustersCacheInvalidation() {
+	mockClusters := []*egoscale.SKSCluster{{ID: &testSKSClusterID}}
+
+	// Set up cache entry
+	ts.p.manager.sksClustersCacheMu.Lock()
+	ts.p.manager.sksClustersCache = &sksClustersCacheEntry{
+		clusters:  mockClusters,
+		expiredAt: time.Now().Add(5 * time.Minute),
+	}
+	ts.p.manager.sksClustersCacheMu.Unlock()
+
+	// Verify cache exists
+	ts.p.manager.sksClustersCacheMu.RLock()
+	ts.Require().NotNil(ts.p.manager.sksClustersCache)
+	ts.p.manager.sksClustersCacheMu.RUnlock()
+
+	// Invalidate
+	ts.p.manager.InvalidateSKSClustersCache()
+
+	// Verify cache is cleared
+	ts.p.manager.sksClustersCacheMu.RLock()
+	ts.Require().Nil(ts.p.manager.sksClustersCache)
+	ts.p.manager.sksClustersCacheMu.RUnlock()
+}
+
+func (ts *cloudProviderTestSuite) TestGetInstancePoolCached() {
+	mockInstancePool := createMockInstancePool(testInstancePoolID, testInstancePoolName)
+	ts.testInstancePoolCacheMissHitPattern(testInstancePoolID, mockInstancePool)
+}
+
+func (ts *cloudProviderTestSuite) TestInstancePoolCacheInvalidation() {
+	mockInstancePool := createMockInstancePool(testInstancePoolID, testInstancePoolName)
+
+	// Add entry to cache and verify it exists
+	ts.setupInstancePoolCacheEntry(testInstancePoolID, mockInstancePool, 5*time.Minute)
+	ts.verifyInstancePoolCacheExists(testInstancePoolID, true)
+
+	// Invalidate cache by ID and verify entry is removed
+	ts.p.manager.InvalidateInstancePoolCacheByID(testInstancePoolID)
+	ts.verifyInstancePoolCacheExists(testInstancePoolID, false)
+}
+
+func (ts *cloudProviderTestSuite) TestInstancePoolCacheInvalidationWithInstances() {
+	mockInstancePool := &egoscale.InstancePool{
+		ID:   &testInstancePoolID,
+		Name: &testInstancePoolName,
+	}
+
+	mockInstance := &egoscale.Instance{
+		ID:   &testInstanceID,
+		Name: &testInstanceName,
+		Manager: &egoscale.InstanceManager{
+			ID:   testInstancePoolID,
+			Type: "instance-pool",
+		},
+	}
+
+	// Add instance pool and instance to cache
+	ts.p.manager.instancePoolCacheMu.Lock()
+	ts.p.manager.instancePoolCache[testInstancePoolID] = &instancePoolCacheEntry{
+		instancePool: mockInstancePool,
+		expiredAt:    time.Now().Add(5 * time.Minute),
+	}
+	ts.p.manager.instancePoolCacheMu.Unlock()
+
+	ts.p.manager.instanceCacheMu.Lock()
+	ts.p.manager.instanceCache[testInstanceID] = &instanceCacheEntry{
+		instance:  mockInstance,
+		expiredAt: time.Now().Add(5 * time.Minute),
+	}
+	ts.p.manager.instanceCacheMu.Unlock()
+
+	// Invalidate instance pool cache (should remove both pool and related instances)
+	ts.p.manager.InvalidateInstancePoolCache(mockInstancePool)
+
+	// Verify both entries are removed
+	ts.p.manager.instancePoolCacheMu.RLock()
+	_, poolExists := ts.p.manager.instancePoolCache[testInstancePoolID]
+	ts.p.manager.instancePoolCacheMu.RUnlock()
+	ts.Require().False(poolExists)
+
+	ts.p.manager.instanceCacheMu.RLock()
+	_, instanceExists := ts.p.manager.instanceCache[testInstanceID]
+	ts.p.manager.instanceCacheMu.RUnlock()
+	ts.Require().False(instanceExists)
+}
+
+func (ts *cloudProviderTestSuite) TestCacheExpiredCleanup() {
+	// Add expired entries to all caches
+	expiredTime := time.Now().Add(-1 * time.Minute)
+
+	// Instance cache
+	ts.p.manager.instanceCacheMu.Lock()
+	ts.p.manager.instanceCache[testInstanceID] = &instanceCacheEntry{
+		instance:  &egoscale.Instance{ID: &testInstanceID},
+		expiredAt: expiredTime,
+	}
+	ts.p.manager.instanceCacheMu.Unlock()
+
+	// Quota cache
+	ts.p.manager.quotaCacheMu.Lock()
+	ts.p.manager.quotaCache = &quotaCacheEntry{
+		quota:     100,
+		expiredAt: expiredTime,
+	}
+	ts.p.manager.quotaCacheMu.Unlock()
+
+	// SKS clusters cache
+	ts.p.manager.sksClustersCacheMu.Lock()
+	ts.p.manager.sksClustersCache = &sksClustersCacheEntry{
+		clusters:  []*egoscale.SKSCluster{{ID: &testSKSClusterID}},
+		expiredAt: expiredTime,
+	}
+	ts.p.manager.sksClustersCacheMu.Unlock()
+
+	// Instance pool cache
+	ts.p.manager.instancePoolCacheMu.Lock()
+	ts.p.manager.instancePoolCache[testInstancePoolID] = &instancePoolCacheEntry{
+		instancePool: &egoscale.InstancePool{ID: &testInstancePoolID},
+		expiredAt:    expiredTime,
+	}
+	ts.p.manager.instancePoolCacheMu.Unlock()
+
+	// Run cleanup methods
+	ts.p.manager.ClearExpiredInstanceCache()
+	ts.p.manager.ClearExpiredQuotaCache()
+	ts.p.manager.ClearExpiredSKSClustersCache()
+	ts.p.manager.ClearExpiredInstancePoolCache()
+
+	// Verify all expired entries are removed
+	ts.p.manager.instanceCacheMu.RLock()
+	ts.Require().Empty(ts.p.manager.instanceCache)
+	ts.p.manager.instanceCacheMu.RUnlock()
+
+	ts.p.manager.quotaCacheMu.RLock()
+	ts.Require().Nil(ts.p.manager.quotaCache)
+	ts.p.manager.quotaCacheMu.RUnlock()
+
+	ts.p.manager.sksClustersCacheMu.RLock()
+	ts.Require().Nil(ts.p.manager.sksClustersCache)
+	ts.p.manager.sksClustersCacheMu.RUnlock()
+
+	ts.p.manager.instancePoolCacheMu.RLock()
+	ts.Require().Empty(ts.p.manager.instancePoolCache)
+	ts.p.manager.instancePoolCacheMu.RUnlock()
+}
+
+func (ts *cloudProviderTestSuite) TestCacheConcurrency() {
+	mockInstance := &egoscale.Instance{
+		ID:    &testInstanceID,
+		Name:  &testInstanceName,
+		State: &testInstanceState,
+	}
+
+	// Setup mock to handle concurrent calls
+	ts.p.manager.client.(*exoscaleClientMock).
+		On("GetInstance", ts.p.manager.ctx, ts.p.manager.zone, testInstanceID).
+		Return(mockInstance, nil)
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	results := make([]*egoscale.Instance, numGoroutines)
+
+	// Test concurrent reads
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			instance, err := ts.p.manager.GetInstanceCached(ts.p.manager.ctx, ts.p.manager.zone, testInstanceID)
+			ts.Require().NoError(err)
+			results[index] = instance
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all goroutines got the same instance
+	for i := 0; i < numGoroutines; i++ {
+		ts.Require().Equal(mockInstance, results[i])
+	}
+
+	// The API should have been called at least once but not more than a few times
+	// (due to potential race conditions during initial cache population)
+	ts.p.manager.client.(*exoscaleClientMock).AssertExpectations(ts.T())
+}
+
+func (ts *cloudProviderTestSuite) TestJitterFunctionality() {
+	// Test jitter for different TTL values
+	testCases := []struct {
+		name string
+		ttl  time.Duration
+	}{
+		{"5 minutes", 5 * time.Minute},
+		{"1 hour", 1 * time.Hour},
+		{"10 minutes", 10 * time.Minute},
+	}
+
+	for _, tc := range testCases {
+		ts.Run(tc.name, func() {
+			// Test jitter multiple times to ensure it varies
+			jitteredTTLs := make(map[time.Duration]bool)
+
+			for i := 0; i < 10; i++ {
+				jitteredTTL := ts.p.manager.addJitter(tc.ttl)
+				jitteredTTLs[jitteredTTL] = true
+
+				// Verify jitter is within expected bounds
+				minExpected := tc.ttl + time.Duration(float64(tc.ttl.Nanoseconds())*jitterMinPercent/100)
+				maxExpected := tc.ttl + time.Duration(float64(tc.ttl.Nanoseconds())*jitterMaxPercent/100)
+
+				ts.Require().True(jitteredTTL >= minExpected && jitteredTTL <= maxExpected,
+					"Jittered TTL %v is outside expected range [%v, %v]", jitteredTTL, minExpected, maxExpected)
+			}
+
+			// Verify that we got different values (jitter is working)
+			ts.Require().GreaterOrEqual(len(jitteredTTLs), 2, "Jitter should produce different values across multiple calls")
+		})
+	}
+}
+
+func (ts *cloudProviderTestSuite) TestCacheJitterInPractice() {
+	mockInstance := &egoscale.Instance{
+		ID:   &testInstanceID,
+		Name: &testInstanceName,
+		Manager: &egoscale.InstanceManager{
+			ID:   testInstancePoolID,
+			Type: "instance-pool",
+		},
+		State: &testInstanceState,
+	}
+
+	// Mock the API call
+	ts.p.manager.client.(*exoscaleClientMock).
+		On("GetInstance", ts.p.manager.ctx, ts.p.manager.zone, testInstanceID).
+		Return(mockInstance, nil).Once()
+
+	// Create multiple instances with the same TTL and verify they have different expiration times
+	var expirationTimes []time.Time
+
+	for i := 0; i < 5; i++ {
+		// Clear cache between calls to force new cache entries
+		ts.p.manager.InvalidateInstanceCache(testInstanceID)
+
+		// Call the cached method
+		_, err := ts.p.manager.GetInstanceCached(ts.p.manager.ctx, ts.p.manager.zone, testInstanceID)
+		ts.Require().NoError(err)
+
+		// Get the expiration time from cache
+		ts.p.manager.instanceCacheMu.RLock()
+		if entry, exists := ts.p.manager.instanceCache[testInstanceID]; exists {
+			expirationTimes = append(expirationTimes, entry.expiredAt)
+		}
+		ts.p.manager.instanceCacheMu.RUnlock()
+
+		// Reset mock expectations for next iteration
+		if i < 4 { // Don't add expectation for the last iteration
+			ts.p.manager.client.(*exoscaleClientMock).
+				On("GetInstance", ts.p.manager.ctx, ts.p.manager.zone, testInstanceID).
+				Return(mockInstance, nil).Once()
+		}
+	}
+
+	// Verify we have different expiration times (jitter is working)
+	uniqueTimes := make(map[time.Time]bool)
+	for _, expTime := range expirationTimes {
+		uniqueTimes[expTime] = true
+	}
+
+	ts.Require().GreaterOrEqual(len(uniqueTimes), 2,
+		"Cache entries should have different expiration times due to jitter")
+}

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_instance_pool.go
@@ -90,6 +90,9 @@ func (n *instancePoolNodeGroup) IncreaseSize(delta int) error {
 
 	n.instancePool.Size = &targetSize
 
+	// Invalidate cache for all instances in the pool since new instances may have been created
+	n.m.InvalidateInstancePoolCache(n.instancePool)
+
 	return nil
 }
 
@@ -120,6 +123,9 @@ func (n *instancePoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 		errorf("unable to evict instances from Instance Pool %s: %v", *n.instancePool.ID, err)
 		return err
 	}
+
+	// Invalidate cache for deleted instances
+	n.m.InvalidateInstanceCacheMultiple(instanceIDs)
 
 	if err := n.waitUntilRunning(n.m.ctx); err != nil {
 		return err
@@ -162,13 +168,15 @@ func (n *instancePoolNodeGroup) Debug() string {
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
 func (n *instancePoolNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
-	nodes := make([]cloudprovider.Instance, len(*n.instancePool.InstanceIDs))
-	for i, id := range *n.instancePool.InstanceIDs {
-		instance, err := n.m.client.GetInstance(n.m.ctx, n.m.zone, id)
-		if err != nil {
-			errorf("unable to retrieve Compute instance %s: %v", id, err)
-			return nil, err
-		}
+	// Use batch method to get all instances efficiently
+	instances, err := n.m.GetInstancesCached(n.m.ctx, n.m.zone, *n.instancePool.InstanceIDs)
+	if err != nil {
+		errorf("unable to retrieve instances for instance pool %s: %v", *n.instancePool.ID, err)
+		return nil, err
+	}
+
+	nodes := make([]cloudprovider.Instance, len(instances))
+	for i, instance := range instances {
 		nodes[i] = toInstance(instance)
 	}
 
@@ -217,7 +225,7 @@ func (n *instancePoolNodeGroup) GetOptions(_ config.NodeGroupAutoscalingOptions)
 
 func (n *instancePoolNodeGroup) waitUntilRunning(ctx context.Context) error {
 	return pollCmd(ctx, func() (bool, error) {
-		instancePool, err := n.m.client.GetInstancePool(ctx, n.m.zone, n.Id())
+		instancePool, err := n.m.GetInstancePoolCached(ctx, n.m.zone, n.Id())
 		if err != nil {
 			errorf("unable to retrieve Instance Pool %s: %s", n.Id(), err)
 			return false, err

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_node_group_sks_nodepool.go
@@ -91,6 +91,17 @@ func (n *sksNodepoolNodeGroup) IncreaseSize(delta int) error {
 
 	n.sksNodepool.Size = &targetSize
 
+	// Invalidate cache for all instances in the underlying instance pool since new instances may have been created
+	instancePool, err := n.m.GetInstancePoolCached(n.m.ctx, n.m.zone, *n.sksNodepool.InstancePoolID)
+	if err != nil {
+		// Log error but don't fail - cache invalidation is not critical
+		errorf("unable to get instance pool for cache invalidation: %v", err)
+	} else {
+		n.m.InvalidateInstancePoolCache(instancePool)
+		// Also invalidate the instance pool cache entry itself since it may have changed
+		n.m.InvalidateInstancePoolCacheByID(*n.sksNodepool.InstancePoolID)
+	}
+
 	return nil
 }
 
@@ -127,6 +138,9 @@ func (n *sksNodepoolNodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 		errorf("unable to evict instances from SKS Nodepool %s: %v", *n.sksNodepool.ID, err)
 		return err
 	}
+
+	// Invalidate cache for deleted instances
+	n.m.InvalidateInstanceCacheMultiple(instanceIDs)
 
 	if err := n.waitUntilRunning(n.m.ctx); err != nil {
 		return err
@@ -169,7 +183,7 @@ func (n *sksNodepoolNodeGroup) Debug() string {
 // Other fields are optional.
 // This list should include also instances that might have not become a kubernetes node yet.
 func (n *sksNodepoolNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
-	instancePool, err := n.m.client.GetInstancePool(n.m.ctx, n.m.zone, *n.sksNodepool.InstancePoolID)
+	instancePool, err := n.m.GetInstancePoolCached(n.m.ctx, n.m.zone, *n.sksNodepool.InstancePoolID)
 	if err != nil {
 		errorf(
 			"unable to retrieve Instance Pool %s managed by SKS Nodepool %s",
@@ -179,13 +193,15 @@ func (n *sksNodepoolNodeGroup) Nodes() ([]cloudprovider.Instance, error) {
 		return nil, err
 	}
 
-	nodes := make([]cloudprovider.Instance, len(*instancePool.InstanceIDs))
-	for i, id := range *instancePool.InstanceIDs {
-		instance, err := n.m.client.GetInstance(n.m.ctx, n.m.zone, id)
-		if err != nil {
-			errorf("unable to retrieve Compute instance %s: %v", id, err)
-			return nil, err
-		}
+	// Use batch method to get all instances efficiently
+	instances, err := n.m.GetInstancesCached(n.m.ctx, n.m.zone, *instancePool.InstanceIDs)
+	if err != nil {
+		errorf("unable to retrieve instances for nodepool %s: %v", *n.sksNodepool.ID, err)
+		return nil, err
+	}
+
+	nodes := make([]cloudprovider.Instance, len(instances))
+	for i, instance := range instances {
 		nodes[i] = toInstance(instance)
 	}
 
@@ -234,7 +250,7 @@ func (n *sksNodepoolNodeGroup) GetOptions(_ config.NodeGroupAutoscalingOptions) 
 
 func (n *sksNodepoolNodeGroup) waitUntilRunning(ctx context.Context) error {
 	return pollCmd(ctx, func() (bool, error) {
-		instancePool, err := n.m.client.GetInstancePool(ctx, n.m.zone, n.Id())
+		instancePool, err := n.m.GetInstancePoolCached(ctx, n.m.zone, n.Id())
 		if err != nil {
 			errorf("unable to retrieve Instance Pool %s: %s", n.Id(), err)
 			return false, err


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds an in-memory cache for the exoscale cloudprovider.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/7543

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
