### PR TITLE
feat(cluster-autoscaler/exoscale): implement caching

### DIFF
--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cache.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cache.go
@@ -1,0 +1,495 @@
+package exoscale
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	egoscale "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2"
+	"k8s.io/klog/v2"
+)
+
+// Cache TTL durations for different resource types
+const (
+	// cacheTTLInstance defines how long compute instance data is cached
+	cacheTTLInstance = 5 * time.Minute
+
+	// cacheTTLInstancePool defines how long instance pool data is cached
+	cacheTTLInstancePool = 5 * time.Minute
+
+	// cacheTTLSKSCluster defines how long SKS cluster data is cached
+	cacheTTLSKSCluster = 10 * time.Minute
+
+	// cacheTTLQuota defines how long quota information is cached
+	cacheTTLQuota = 1 * time.Hour
+
+	// cacheJitterMinPercent defines the minimum jitter percentage added to TTL
+	cacheJitterMinPercent = 10
+
+	// cacheJitterMaxPercent defines the maximum jitter percentage added to TTL
+	cacheJitterMaxPercent = 30
+)
+
+// Cache entry structs with TTL and expiration tracking
+
+// cachedInstance represents a cached compute instance with expiration metadata
+type cachedInstance struct {
+	data      *egoscale.Instance
+	fetchedAt time.Time
+	ttl       time.Duration
+}
+
+// isExpired checks if the cached instance has exceeded its TTL
+func (c *cachedInstance) isExpired() bool {
+	return time.Since(c.fetchedAt) > c.ttl
+}
+
+// cachedInstancePool represents a cached instance pool with expiration metadata
+type cachedInstancePool struct {
+	data      *egoscale.InstancePool
+	fetchedAt time.Time
+	ttl       time.Duration
+}
+
+// isExpired checks if the cached instance pool has exceeded its TTL
+func (c *cachedInstancePool) isExpired() bool {
+	return time.Since(c.fetchedAt) > c.ttl
+}
+
+// cachedSKSCluster represents a cached SKS cluster with expiration metadata
+type cachedSKSCluster struct {
+	data      *egoscale.SKSCluster
+	fetchedAt time.Time
+	ttl       time.Duration
+}
+
+// isExpired checks if the cached SKS cluster has exceeded its TTL
+func (c *cachedSKSCluster) isExpired() bool {
+	return time.Since(c.fetchedAt) > c.ttl
+}
+
+// cachedQuota represents cached quota data with expiration metadata
+type cachedQuota struct {
+	data      *egoscale.Quota
+	fetchedAt time.Time
+	ttl       time.Duration
+}
+
+// isExpired checks if the cached quota has exceeded its TTL
+func (c *cachedQuota) isExpired() bool {
+	return time.Since(c.fetchedAt) > c.ttl
+}
+
+// cacheMetrics tracks cache hit and miss statistics per resource type
+type cacheMetrics struct {
+	instanceHits       int64
+	instanceMisses     int64
+	instancePoolHits   int64
+	instancePoolMisses int64
+	sksClusterHits     int64
+	sksClusterMisses   int64
+	quotaHits          int64
+	quotaMisses        int64
+}
+
+// exoscaleCache implements the exoscaleClient interface with caching
+type exoscaleCache struct {
+	// Wrapped client
+	client exoscaleClient
+
+	// Cache storage
+	instancesCache     map[string]*cachedInstance
+	instancePoolsCache map[string]*cachedInstancePool
+	sksClustersCache   []*cachedSKSCluster
+	quotaCache         map[string]*cachedQuota
+
+	// Thread-safety
+	mu sync.RWMutex
+
+	// Configuration
+	jitterEnabled bool
+
+	// Metrics
+	metrics cacheMetrics
+}
+
+// calculateTTLWithJitter adds random jitter (cacheJitterMinPercent-cacheJitterMaxPercent%) to the base TTL
+func calculateTTLWithJitter(baseTTL time.Duration, jitterEnabled bool) time.Duration {
+	if !jitterEnabled {
+		return baseTTL
+	}
+	// Random jitter between cacheJitterMinPercent% and cacheJitterMaxPercent%
+	jitterRange := cacheJitterMaxPercent - cacheJitterMinPercent + 1
+	jitterPercent := cacheJitterMinPercent + rand.Intn(jitterRange)
+	jitter := time.Duration(float64(baseTTL) * float64(jitterPercent) / 100.0)
+	return baseTTL + jitter
+}
+
+// newExoscaleCache creates a new caching layer that wraps an exoscaleClient
+func newExoscaleCache(client exoscaleClient, jitterEnabled bool) *exoscaleCache {
+	return &exoscaleCache{
+		client:             client,
+		instancesCache:     make(map[string]*cachedInstance),
+		instancePoolsCache: make(map[string]*cachedInstancePool),
+		sksClustersCache:   make([]*cachedSKSCluster, 0),
+		quotaCache:         make(map[string]*cachedQuota),
+		jitterEnabled:      jitterEnabled,
+	}
+}
+
+// GetInstance retrieves an instance with caching support
+// Implements cach hit path, cache miss path, and stale data serving on API failure
+func (c *exoscaleCache) GetInstance(ctx context.Context, zone string, id string) (*egoscale.Instance, error) {
+	// Cache hit path - read lock for concurrent reads
+	c.mu.RLock()
+	cached, ok := c.instancesCache[id]
+	c.mu.RUnlock()
+
+	if ok && !cached.isExpired() {
+		// Cache hit - return cached data
+		atomic.AddInt64(&c.metrics.instanceHits, 1)
+		klog.V(5).Infof("Cache hit for instance %s", id)
+		return cached.data, nil
+	}
+
+	// Cache miss or expired - acquire write lock
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock (another goroutine may have updated)
+	if cached, ok := c.instancesCache[id]; ok && !cached.isExpired() {
+		atomic.AddInt64(&c.metrics.instanceHits, 1)
+		return cached.data, nil
+	}
+
+	// Fetch from API
+	instance, err := c.client.GetInstance(ctx, zone, id)
+	atomic.AddInt64(&c.metrics.instanceMisses, 1)
+
+	if err != nil {
+		// API failure - serve stale data if available (graceful degradation)
+		if cached != nil {
+			klog.Warningf("API call failed for instance %s, serving stale data: %v", id, err)
+			// Extend TTL to retry later
+			cached.ttl = calculateTTLWithJitter(cacheTTLInstance, c.jitterEnabled)
+			cached.fetchedAt = time.Now()
+			return cached.data, nil
+		}
+		// No stale data available
+		klog.V(3).Infof("Cache miss for instance %s, API call failed: %v", id, err)
+		return nil, err
+	}
+
+	// Store in cache with TTL + jitter
+	c.instancesCache[id] = &cachedInstance{
+		data:      instance,
+		fetchedAt: time.Now(),
+		ttl:       calculateTTLWithJitter(cacheTTLInstance, c.jitterEnabled),
+	}
+
+	klog.V(3).Infof("Cache miss for instance %s, fetched from API and stored", id)
+	return instance, nil
+}
+
+// GetInstancePool retrieves an instance pool with caching support
+func (c *exoscaleCache) GetInstancePool(ctx context.Context, zone string, id string) (*egoscale.InstancePool, error) {
+	// Cache hit path
+	c.mu.RLock()
+	cached, ok := c.instancePoolsCache[id]
+	c.mu.RUnlock()
+
+	if ok && !cached.isExpired() {
+		atomic.AddInt64(&c.metrics.instancePoolHits, 1)
+		klog.V(5).Infof("Cache hit for instance pool %s", id)
+		return cached.data, nil
+	}
+
+	// Cache miss or expired
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check
+	if cached, ok := c.instancePoolsCache[id]; ok && !cached.isExpired() {
+		atomic.AddInt64(&c.metrics.instancePoolHits, 1)
+		return cached.data, nil
+	}
+
+	// Fetch from API
+	pool, err := c.client.GetInstancePool(ctx, zone, id)
+	atomic.AddInt64(&c.metrics.instancePoolMisses, 1)
+
+	if err != nil {
+		// Serve stale data on API failure
+		if cached != nil {
+			klog.Warningf("API call failed for instance pool %s, serving stale data: %v", id, err)
+			cached.ttl = calculateTTLWithJitter(cacheTTLInstancePool, c.jitterEnabled)
+			cached.fetchedAt = time.Now()
+			return cached.data, nil
+		}
+		klog.V(3).Infof("Cache miss for instance pool %s, API call failed: %v", id, err)
+		return nil, err
+	}
+
+	// Store in cache
+	c.instancePoolsCache[id] = &cachedInstancePool{
+		data:      pool,
+		fetchedAt: time.Now(),
+		ttl:       calculateTTLWithJitter(cacheTTLInstancePool, c.jitterEnabled),
+	}
+
+	klog.V(3).Infof("Cache miss for instance pool %s, fetched from API and stored", id)
+	return pool, nil
+}
+
+// ListSKSClusters retrieves SKS clusters with list caching
+func (c *exoscaleCache) ListSKSClusters(ctx context.Context, zone string) ([]*egoscale.SKSCluster, error) {
+	// Check if we have cached SKS clusters that are still valid
+	c.mu.RLock()
+	if len(c.sksClustersCache) > 0 && !c.sksClustersCache[0].isExpired() {
+		c.mu.RUnlock()
+		atomic.AddInt64(&c.metrics.sksClusterHits, 1)
+		klog.V(5).Infof("Cache hit for SKS clusters list")
+		// Extract data from cached entries
+		result := make([]*egoscale.SKSCluster, len(c.sksClustersCache))
+		for i, cached := range c.sksClustersCache {
+			result[i] = cached.data
+		}
+		return result, nil
+	}
+	c.mu.RUnlock()
+
+	// Cache miss or expired
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check
+	if len(c.sksClustersCache) > 0 && !c.sksClustersCache[0].isExpired() {
+		atomic.AddInt64(&c.metrics.sksClusterHits, 1)
+		result := make([]*egoscale.SKSCluster, len(c.sksClustersCache))
+		for i, cached := range c.sksClustersCache {
+			result[i] = cached.data
+		}
+		return result, nil
+	}
+
+	// Fetch from API
+	clusters, err := c.client.ListSKSClusters(ctx, zone)
+	atomic.AddInt64(&c.metrics.sksClusterMisses, 1)
+
+	if err != nil {
+		// Serve stale data on API failure
+		if len(c.sksClustersCache) > 0 {
+			klog.Warningf("API call failed for SKS clusters, serving stale data: %v", err)
+			// Extend TTL on all cached entries
+			now := time.Now()
+			ttl := calculateTTLWithJitter(cacheTTLSKSCluster, c.jitterEnabled)
+			for _, cached := range c.sksClustersCache {
+				cached.fetchedAt = now
+				cached.ttl = ttl
+			}
+			result := make([]*egoscale.SKSCluster, len(c.sksClustersCache))
+			for i, cached := range c.sksClustersCache {
+				result[i] = cached.data
+			}
+			return result, nil
+		}
+		klog.V(3).Infof("Cache miss for SKS clusters, API call failed: %v", err)
+		return nil, err
+	}
+
+	// Store in cache
+	now := time.Now()
+	ttl := calculateTTLWithJitter(cacheTTLSKSCluster, c.jitterEnabled)
+	c.sksClustersCache = make([]*cachedSKSCluster, len(clusters))
+	for i, cluster := range clusters {
+		c.sksClustersCache[i] = &cachedSKSCluster{
+			data:      cluster,
+			fetchedAt: now,
+			ttl:       ttl,
+		}
+	}
+
+	klog.V(3).Infof("Cache miss for SKS clusters, fetched %d clusters from API", len(clusters))
+	return clusters, nil
+}
+
+// GetQuota retrieves quota information with 1-hour TTL caching
+func (c *exoscaleCache) GetQuota(ctx context.Context, zone string, resource string) (*egoscale.Quota, error) {
+	// Cache hit path
+	c.mu.RLock()
+	cached, ok := c.quotaCache[resource]
+	c.mu.RUnlock()
+
+	if ok && !cached.isExpired() {
+		atomic.AddInt64(&c.metrics.quotaHits, 1)
+		klog.V(5).Infof("Cache hit for quota %s", resource)
+		return cached.data, nil
+	}
+
+	// Cache miss or expired
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check
+	if cached, ok := c.quotaCache[resource]; ok && !cached.isExpired() {
+		atomic.AddInt64(&c.metrics.quotaHits, 1)
+		return cached.data, nil
+	}
+
+	// Fetch from API
+	quota, err := c.client.GetQuota(ctx, zone, resource)
+	atomic.AddInt64(&c.metrics.quotaMisses, 1)
+
+	if err != nil {
+		// Serve stale data on API failure
+		if cached != nil {
+			klog.Warningf("API call failed for quota %s, serving stale data: %v", resource, err)
+			cached.ttl = calculateTTLWithJitter(cacheTTLQuota, c.jitterEnabled)
+			cached.fetchedAt = time.Now()
+			return cached.data, nil
+		}
+		klog.V(3).Infof("Cache miss for quota %s, API call failed: %v", resource, err)
+		return nil, err
+	}
+
+	// Store in cache with 1-hour TTL
+	c.quotaCache[resource] = &cachedQuota{
+		data:      quota,
+		fetchedAt: time.Now(),
+		ttl:       calculateTTLWithJitter(cacheTTLQuota, c.jitterEnabled),
+	}
+
+	klog.V(3).Infof("Cache miss for quota %s, fetched from API and stored", resource)
+	return quota, nil
+}
+
+// Pass-through methods (no caching for write operations)
+
+// EvictInstancePoolMembers passes through to the underlying client (write operation)
+func (c *exoscaleCache) EvictInstancePoolMembers(ctx context.Context, zone string, instancePool *egoscale.InstancePool, members []string) error {
+	return c.client.EvictInstancePoolMembers(ctx, zone, instancePool, members)
+}
+
+// EvictSKSNodepoolMembers passes through to the underlying client (write operation)
+func (c *exoscaleCache) EvictSKSNodepoolMembers(ctx context.Context, zone string, cluster *egoscale.SKSCluster, nodepool *egoscale.SKSNodepool, members []string) error {
+	return c.client.EvictSKSNodepoolMembers(ctx, zone, cluster, nodepool, members)
+}
+
+// ScaleInstancePool passes through to the underlying client (write operation)
+func (c *exoscaleCache) ScaleInstancePool(ctx context.Context, zone string, instancePool *egoscale.InstancePool, size int64) error {
+	return c.client.ScaleInstancePool(ctx, zone, instancePool, size)
+}
+
+// ScaleSKSNodepool passes through to the underlying client (write operation)
+func (c *exoscaleCache) ScaleSKSNodepool(ctx context.Context, zone string, cluster *egoscale.SKSCluster, nodepool *egoscale.SKSNodepool, size int64) error {
+	return c.client.ScaleSKSNodepool(ctx, zone, cluster, nodepool, size)
+}
+
+// Observability and management methods
+
+// CacheMetrics contains cache performance statistics
+type CacheMetrics struct {
+	InstanceHits        int64
+	InstanceMisses      int64
+	InstanceHitRate     float64
+	InstancePoolHits    int64
+	InstancePoolMisses  int64
+	InstancePoolHitRate float64
+	SKSClusterHits      int64
+	SKSClusterMisses    int64
+	SKSClusterHitRate   float64
+	QuotaHits           int64
+	QuotaMisses         int64
+	QuotaHitRate        float64
+	TotalHits           int64
+	TotalMisses         int64
+	OverallHitRate      float64
+}
+
+// GetMetrics returns current cache performance metrics with hit rates
+func (c *exoscaleCache) GetMetrics() CacheMetrics {
+	// Read metrics atomically (no lock needed for atomic reads)
+	instanceHits := atomic.LoadInt64(&c.metrics.instanceHits)
+	instanceMisses := atomic.LoadInt64(&c.metrics.instanceMisses)
+	instancePoolHits := atomic.LoadInt64(&c.metrics.instancePoolHits)
+	instancePoolMisses := atomic.LoadInt64(&c.metrics.instancePoolMisses)
+	sksClusterHits := atomic.LoadInt64(&c.metrics.sksClusterHits)
+	sksClusterMisses := atomic.LoadInt64(&c.metrics.sksClusterMisses)
+	quotaHits := atomic.LoadInt64(&c.metrics.quotaHits)
+	quotaMisses := atomic.LoadInt64(&c.metrics.quotaMisses)
+
+	// Calculate hit rates
+	instanceHitRate := calculateHitRate(instanceHits, instanceMisses)
+	instancePoolHitRate := calculateHitRate(instancePoolHits, instancePoolMisses)
+	sksClusterHitRate := calculateHitRate(sksClusterHits, sksClusterMisses)
+	quotaHitRate := calculateHitRate(quotaHits, quotaMisses)
+
+	totalHits := instanceHits + instancePoolHits + sksClusterHits + quotaHits
+	totalMisses := instanceMisses + instancePoolMisses + sksClusterMisses + quotaMisses
+	overallHitRate := calculateHitRate(totalHits, totalMisses)
+
+	return CacheMetrics{
+		InstanceHits:        instanceHits,
+		InstanceMisses:      instanceMisses,
+		InstanceHitRate:     instanceHitRate,
+		InstancePoolHits:    instancePoolHits,
+		InstancePoolMisses:  instancePoolMisses,
+		InstancePoolHitRate: instancePoolHitRate,
+		SKSClusterHits:      sksClusterHits,
+		SKSClusterMisses:    sksClusterMisses,
+		SKSClusterHitRate:   sksClusterHitRate,
+		QuotaHits:           quotaHits,
+		QuotaMisses:         quotaMisses,
+		QuotaHitRate:        quotaHitRate,
+		TotalHits:           totalHits,
+		TotalMisses:         totalMisses,
+		OverallHitRate:      overallHitRate,
+	}
+}
+
+// calculateHitRate computes the hit rate as hits / (hits + misses)
+// Returns 0.0 if there are no operations yet
+func calculateHitRate(hits, misses int64) float64 {
+	total := hits + misses
+	if total == 0 {
+		return 0.0
+	}
+	return float64(hits) / float64(total)
+}
+
+// InvalidateCache clears all cached entries and resets metrics
+// Useful for testing, debugging, or forcing a full refresh
+func (c *exoscaleCache) InvalidateCache() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Clear all cache maps
+	c.instancesCache = make(map[string]*cachedInstance)
+	c.instancePoolsCache = make(map[string]*cachedInstancePool)
+	c.sksClustersCache = make([]*cachedSKSCluster, 0)
+	c.quotaCache = make(map[string]*cachedQuota)
+
+	// Reset metrics
+	atomic.StoreInt64(&c.metrics.instanceHits, 0)
+	atomic.StoreInt64(&c.metrics.instanceMisses, 0)
+	atomic.StoreInt64(&c.metrics.instancePoolHits, 0)
+	atomic.StoreInt64(&c.metrics.instancePoolMisses, 0)
+	atomic.StoreInt64(&c.metrics.sksClusterHits, 0)
+	atomic.StoreInt64(&c.metrics.sksClusterMisses, 0)
+	atomic.StoreInt64(&c.metrics.quotaHits, 0)
+	atomic.StoreInt64(&c.metrics.quotaMisses, 0)
+
+	klog.V(3).Infof("Cache invalidated: all entries and metrics cleared")
+}
+
+// SetJitterEnabled enables or disables TTL jitter
+// Jitter should be enabled in production to prevent thundering herd
+func (c *exoscaleCache) SetJitterEnabled(enabled bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.jitterEnabled = enabled
+	klog.V(3).Infof("Cache jitter enabled set to: %v", enabled)
+}

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cache_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cache_test.go
@@ -1,0 +1,1156 @@
+package exoscale
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	egoscale "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2"
+)
+
+// exoscaleClientMock is defined in exoscale_cloud_provider_test.go and shared across test files
+
+// Test isExpired() with fresh and stale data
+func TestCacheEntry_IsExpired_Fresh(t *testing.T) {
+	entry := &cachedInstance{
+		data:      &egoscale.Instance{},
+		fetchedAt: time.Now(),
+		ttl:       5 * time.Minute,
+	}
+	assert.False(t, entry.isExpired(), "Fresh entry should not be expired")
+}
+
+func TestCacheEntry_IsExpired_Stale(t *testing.T) {
+	entry := &cachedInstance{
+		data:      &egoscale.Instance{},
+		fetchedAt: time.Now().Add(-10 * time.Minute),
+		ttl:       5 * time.Minute,
+	}
+	assert.True(t, entry.isExpired(), "Stale entry should be expired")
+}
+
+func TestCacheEntryPool_IsExpired(t *testing.T) {
+	fresh := &cachedInstancePool{
+		data:      &egoscale.InstancePool{},
+		fetchedAt: time.Now(),
+		ttl:       5 * time.Minute,
+	}
+	assert.False(t, fresh.isExpired())
+
+	stale := &cachedInstancePool{
+		data:      &egoscale.InstancePool{},
+		fetchedAt: time.Now().Add(-10 * time.Minute),
+		ttl:       5 * time.Minute,
+	}
+	assert.True(t, stale.isExpired())
+}
+
+func TestCacheEntrySKS_IsExpired(t *testing.T) {
+	fresh := &cachedSKSCluster{
+		data:      &egoscale.SKSCluster{},
+		fetchedAt: time.Now(),
+		ttl:       10 * time.Minute,
+	}
+	assert.False(t, fresh.isExpired())
+
+	stale := &cachedSKSCluster{
+		data:      &egoscale.SKSCluster{},
+		fetchedAt: time.Now().Add(-15 * time.Minute),
+		ttl:       10 * time.Minute,
+	}
+	assert.True(t, stale.isExpired())
+}
+
+func TestCacheEntryQuota_IsExpired(t *testing.T) {
+	fresh := &cachedQuota{
+		data:      &egoscale.Quota{},
+		fetchedAt: time.Now(),
+		ttl:       1 * time.Hour,
+	}
+	assert.False(t, fresh.isExpired())
+
+	stale := &cachedQuota{
+		data:      &egoscale.Quota{},
+		fetchedAt: time.Now().Add(-90 * time.Minute),
+		ttl:       1 * time.Hour,
+	}
+	assert.True(t, stale.isExpired())
+}
+
+// Test jitter calculation (verify 10-30% range)
+func TestCalculateTTLWithJitter_Disabled(t *testing.T) {
+	baseTTL := 5 * time.Minute
+	result := calculateTTLWithJitter(baseTTL, false)
+	assert.Equal(t, baseTTL, result, "With jitter disabled, TTL should equal base TTL")
+}
+
+func TestCalculateTTLWithJitter_Enabled(t *testing.T) {
+	baseTTL := 5 * time.Minute
+	minExpected := baseTTL + time.Duration(float64(baseTTL)*0.10) // 10% jitter
+	maxExpected := baseTTL + time.Duration(float64(baseTTL)*0.30) // 30% jitter
+
+	// Test multiple times to verify range
+	for i := 0; i < 100; i++ {
+		result := calculateTTLWithJitter(baseTTL, true)
+		assert.GreaterOrEqual(t, result, minExpected, "TTL with jitter should be at least base + 10%%")
+		assert.LessOrEqual(t, result, maxExpected, "TTL with jitter should be at most base + 30%%")
+	}
+}
+
+func TestCalculateTTLWithJitter_DifferentBaseTTLs(t *testing.T) {
+	testCases := []struct {
+		name    string
+		baseTTL time.Duration
+	}{
+		{"5 minutes", 5 * time.Minute},
+		{"10 minutes", 10 * time.Minute},
+		{"1 hour", 1 * time.Hour},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			minExpected := tc.baseTTL + time.Duration(float64(tc.baseTTL)*0.10)
+			maxExpected := tc.baseTTL + time.Duration(float64(tc.baseTTL)*0.30)
+
+			result := calculateTTLWithJitter(tc.baseTTL, true)
+			assert.GreaterOrEqual(t, result, minExpected)
+			assert.LessOrEqual(t, result, maxExpected)
+		})
+	}
+}
+
+// Test cache initialization
+func TestNewExoscaleCache(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, true)
+
+	assert.NotNil(t, cache, "Cache should not be nil")
+	assert.Equal(t, mockClient, cache.client, "Cache should wrap the provided client")
+	assert.True(t, cache.jitterEnabled, "Jitter should be enabled")
+	assert.NotNil(t, cache.instancesCache, "Instances cache map should be initialized")
+	assert.NotNil(t, cache.instancePoolsCache, "Instance pools cache map should be initialized")
+	assert.NotNil(t, cache.sksClustersCache, "SKS clusters cache should be initialized")
+	assert.NotNil(t, cache.quotaCache, "Quota cache map should be initialized")
+	assert.Equal(t, 0, len(cache.instancesCache), "Instances cache should start empty")
+	assert.Equal(t, 0, len(cache.instancePoolsCache), "Instance pools cache should start empty")
+	assert.Equal(t, 0, len(cache.sksClustersCache), "SKS clusters cache should start empty")
+	assert.Equal(t, 0, len(cache.quotaCache), "Quota cache should start empty")
+}
+
+func TestNewExoscaleCache_JitterDisabled(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	assert.False(t, cache.jitterEnabled, "Jitter should be disabled")
+}
+
+// Test GetInstance cache hit (no API call)
+func TestGetInstance_CacheHit(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	// Pre-populate cache
+	testID := "test-instance-id"
+	cache.instancesCache[testID] = &cachedInstance{
+		data:      &egoscale.Instance{ID: &testID, Name: &[]string{"test-instance"}[0]},
+		fetchedAt: time.Now(),
+		ttl:       5 * time.Minute,
+	}
+
+	// Should not call API
+	instance, err := cache.GetInstance(context.Background(), "ch-gva-2", testID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, instance)
+	assert.Equal(t, testID, *instance.ID)
+	assert.Equal(t, "test-instance", *instance.Name)
+	mockClient.AssertNotCalled(t, "GetInstance")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.instanceHits))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.instanceMisses))
+}
+
+// Test GetInstance cache miss (calls API, stores)
+func TestGetInstance_CacheMiss(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "new-instance-id"
+	expectedInstance := &egoscale.Instance{ID: &testID, Name: &[]string{"new-instance"}[0]}
+	mockClient.On("GetInstance", mock.Anything, "ch-gva-2", testID).Return(expectedInstance, nil)
+
+	instance, err := cache.GetInstance(context.Background(), "ch-gva-2", testID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, instance)
+	assert.Equal(t, testID, *instance.ID)
+	mockClient.AssertCalled(t, "GetInstance", mock.Anything, "ch-gva-2", testID)
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.instanceHits))
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.instanceMisses))
+
+	// Verify it was stored in cache
+	cached, ok := cache.instancesCache[testID]
+	assert.True(t, ok, "Instance should be stored in cache")
+	assert.NotNil(t, cached)
+	assert.Equal(t, expectedInstance, cached.data)
+}
+
+// Test GetInstance expired entry (refreshes from API)
+func TestGetInstance_ExpiredEntry(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "expired-instance-id"
+	// Pre-populate with expired entry
+	cache.instancesCache[testID] = &cachedInstance{
+		data:      &egoscale.Instance{ID: &testID, Name: &[]string{"old-data"}[0]},
+		fetchedAt: time.Now().Add(-10 * time.Minute),
+		ttl:       5 * time.Minute,
+	}
+
+	freshInstance := &egoscale.Instance{ID: &testID, Name: &[]string{"fresh-data"}[0]}
+	mockClient.On("GetInstance", mock.Anything, "ch-gva-2", testID).Return(freshInstance, nil)
+
+	instance, err := cache.GetInstance(context.Background(), "ch-gva-2", testID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, instance)
+	assert.Equal(t, "fresh-data", *instance.Name)
+	mockClient.AssertCalled(t, "GetInstance", mock.Anything, "ch-gva-2", testID)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.instanceMisses))
+}
+
+// Test GetInstance API failure with stale data
+func TestGetInstance_APIFailureWithStaleData(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "stale-instance-id"
+	staleData := &egoscale.Instance{ID: &testID, Name: &[]string{"stale-data"}[0]}
+	// Pre-populate with expired entry
+	cache.instancesCache[testID] = &cachedInstance{
+		data:      staleData,
+		fetchedAt: time.Now().Add(-10 * time.Minute),
+		ttl:       5 * time.Minute,
+	}
+
+	mockClient.On("GetInstance", mock.Anything, "ch-gva-2", testID).Return(nil, assert.AnError)
+
+	instance, err := cache.GetInstance(context.Background(), "ch-gva-2", testID)
+
+	// Should return stale data instead of error
+	assert.NoError(t, err)
+	assert.NotNil(t, instance)
+	assert.Equal(t, "stale-data", *instance.Name)
+	mockClient.AssertCalled(t, "GetInstance", mock.Anything, "ch-gva-2", testID)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.instanceMisses))
+}
+
+// Test GetInstance API failure without cache
+func TestGetInstance_APIFailureWithoutCache(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "nonexistent-instance-id"
+	mockClient.On("GetInstance", mock.Anything, "ch-gva-2", testID).Return(nil, assert.AnError)
+
+	instance, err := cache.GetInstance(context.Background(), "ch-gva-2", testID)
+
+	assert.Error(t, err)
+	assert.Nil(t, instance)
+	mockClient.AssertCalled(t, "GetInstance", mock.Anything, "ch-gva-2", testID)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.instanceMisses))
+}
+
+// Test GetInstance metrics increment
+func TestGetInstance_MetricsIncrement(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "metrics-test-id"
+	cache.instancesCache[testID] = &cachedInstance{
+		data:      &egoscale.Instance{ID: &testID},
+		fetchedAt: time.Now(),
+		ttl:       5 * time.Minute,
+	}
+
+	// Multiple cache hits
+	for i := 0; i < 5; i++ {
+		_, _ = cache.GetInstance(context.Background(), "ch-gva-2", testID)
+	}
+
+	assert.Equal(t, int64(5), atomic.LoadInt64(&cache.metrics.instanceHits))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.instanceMisses))
+}
+
+// Test GetInstancePool hit/miss scenarios
+func TestGetInstancePool_CacheHit(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "test-pool-id"
+	cache.instancePoolsCache[testID] = &cachedInstancePool{
+		data:      &egoscale.InstancePool{ID: &testID, Name: &[]string{"test-pool"}[0]},
+		fetchedAt: time.Now(),
+		ttl:       5 * time.Minute,
+	}
+
+	pool, err := cache.GetInstancePool(context.Background(), "ch-gva-2", testID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, pool)
+	assert.Equal(t, testID, *pool.ID)
+	mockClient.AssertNotCalled(t, "GetInstancePool")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.instancePoolHits))
+}
+
+func TestGetInstancePool_CacheMiss(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "new-pool-id"
+	expectedPool := &egoscale.InstancePool{ID: &testID, Name: &[]string{"new-pool"}[0]}
+	mockClient.On("GetInstancePool", mock.Anything, "ch-gva-2", testID).Return(expectedPool, nil)
+
+	pool, err := cache.GetInstancePool(context.Background(), "ch-gva-2", testID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, pool)
+	assert.Equal(t, testID, *pool.ID)
+	mockClient.AssertCalled(t, "GetInstancePool", mock.Anything, "ch-gva-2", testID)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.instancePoolMisses))
+
+	// Verify stored in cache
+	cached, ok := cache.instancePoolsCache[testID]
+	assert.True(t, ok)
+	assert.Equal(t, expectedPool, cached.data)
+}
+
+// Test ListSKSClusters caching full list
+func TestListSKSClusters_CacheHit(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	// Pre-populate cache with list
+	cluster1 := &egoscale.SKSCluster{ID: &[]string{"cluster-1"}[0], Name: &[]string{"cluster-one"}[0]}
+	cluster2 := &egoscale.SKSCluster{ID: &[]string{"cluster-2"}[0], Name: &[]string{"cluster-two"}[0]}
+	now := time.Now()
+	cache.sksClustersCache = []*cachedSKSCluster{
+		{data: cluster1, fetchedAt: now, ttl: 10 * time.Minute},
+		{data: cluster2, fetchedAt: now, ttl: 10 * time.Minute},
+	}
+
+	clusters, err := cache.ListSKSClusters(context.Background(), "ch-gva-2")
+
+	assert.NoError(t, err)
+	assert.Len(t, clusters, 2)
+	assert.Equal(t, "cluster-1", *clusters[0].ID)
+	assert.Equal(t, "cluster-2", *clusters[1].ID)
+	mockClient.AssertNotCalled(t, "ListSKSClusters")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.sksClusterHits))
+}
+
+func TestListSKSClusters_CacheMiss(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	expectedClusters := []*egoscale.SKSCluster{
+		{ID: &[]string{"cluster-1"}[0], Name: &[]string{"cluster-one"}[0]},
+		{ID: &[]string{"cluster-2"}[0], Name: &[]string{"cluster-two"}[0]},
+	}
+	mockClient.On("ListSKSClusters", mock.Anything, "ch-gva-2").Return(expectedClusters, nil)
+
+	clusters, err := cache.ListSKSClusters(context.Background(), "ch-gva-2")
+
+	assert.NoError(t, err)
+	assert.Len(t, clusters, 2)
+	mockClient.AssertCalled(t, "ListSKSClusters", mock.Anything, "ch-gva-2")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.sksClusterMisses))
+
+	// Verify stored in cache
+	assert.Len(t, cache.sksClustersCache, 2)
+	assert.Equal(t, expectedClusters[0], cache.sksClustersCache[0].data)
+}
+
+// Test GetQuota with 1-hour TTL
+func TestGetQuota_CacheHit(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	resource := "instance"
+	limit := int64(100)
+	cache.quotaCache[resource] = &cachedQuota{
+		data:      &egoscale.Quota{Resource: &resource, Limit: &limit},
+		fetchedAt: time.Now(),
+		ttl:       1 * time.Hour,
+	}
+
+	quota, err := cache.GetQuota(context.Background(), "ch-gva-2", resource)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, quota)
+	assert.Equal(t, int64(100), *quota.Limit)
+	mockClient.AssertNotCalled(t, "GetQuota")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.quotaHits))
+}
+
+func TestGetQuota_CacheMiss(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	resource := "instance"
+	limit := int64(100)
+	expectedQuota := &egoscale.Quota{Resource: &resource, Limit: &limit}
+	mockClient.On("GetQuota", mock.Anything, "ch-gva-2", resource).Return(expectedQuota, nil)
+
+	quota, err := cache.GetQuota(context.Background(), "ch-gva-2", resource)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, quota)
+	assert.Equal(t, int64(100), *quota.Limit)
+	mockClient.AssertCalled(t, "GetQuota", mock.Anything, "ch-gva-2", resource)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&cache.metrics.quotaMisses))
+
+	// Verify 1-hour TTL
+	cached := cache.quotaCache[resource]
+	assert.NotNil(t, cached)
+	assert.Equal(t, 1*time.Hour, cached.ttl)
+}
+
+// Test pass-through methods (always call API)
+func TestEvictInstancePoolMembers_PassThrough(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	pool := &egoscale.InstancePool{ID: &[]string{"pool-id"}[0]}
+	members := []string{"instance-1", "instance-2"}
+	mockClient.On("EvictInstancePoolMembers", mock.Anything, "ch-gva-2", pool, members).Return(nil)
+
+	err := cache.EvictInstancePoolMembers(context.Background(), "ch-gva-2", pool, members)
+
+	assert.NoError(t, err)
+	mockClient.AssertCalled(t, "EvictInstancePoolMembers", mock.Anything, "ch-gva-2", pool, members)
+}
+
+func TestEvictSKSNodepoolMembers_PassThrough(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	cluster := &egoscale.SKSCluster{ID: &[]string{"cluster-id"}[0]}
+	nodepool := &egoscale.SKSNodepool{ID: &[]string{"nodepool-id"}[0]}
+	members := []string{"node-1"}
+	mockClient.On("EvictSKSNodepoolMembers", mock.Anything, "ch-gva-2", cluster, nodepool, members).Return(nil)
+
+	err := cache.EvictSKSNodepoolMembers(context.Background(), "ch-gva-2", cluster, nodepool, members)
+
+	assert.NoError(t, err)
+	mockClient.AssertCalled(t, "EvictSKSNodepoolMembers", mock.Anything, "ch-gva-2", cluster, nodepool, members)
+}
+
+func TestScaleInstancePool_PassThrough(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	pool := &egoscale.InstancePool{ID: &[]string{"pool-id"}[0]}
+	mockClient.On("ScaleInstancePool", mock.Anything, "ch-gva-2", pool, int64(5)).Return(nil)
+
+	err := cache.ScaleInstancePool(context.Background(), "ch-gva-2", pool, 5)
+
+	assert.NoError(t, err)
+	mockClient.AssertCalled(t, "ScaleInstancePool", mock.Anything, "ch-gva-2", pool, int64(5))
+}
+
+func TestScaleSKSNodepool_PassThrough(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	cluster := &egoscale.SKSCluster{ID: &[]string{"cluster-id"}[0]}
+	nodepool := &egoscale.SKSNodepool{ID: &[]string{"nodepool-id"}[0]}
+	mockClient.On("ScaleSKSNodepool", mock.Anything, "ch-gva-2", cluster, nodepool, int64(3)).Return(nil)
+
+	err := cache.ScaleSKSNodepool(context.Background(), "ch-gva-2", cluster, nodepool, 3)
+
+	assert.NoError(t, err)
+	mockClient.AssertCalled(t, "ScaleSKSNodepool", mock.Anything, "ch-gva-2", cluster, nodepool, int64(3))
+}
+
+// Test GetMetrics returning correct hit rates
+func TestGetMetrics_CorrectHitRates(t *testing.T) {
+	cache := newExoscaleCache(nil, false)
+
+	// Set up metrics: 85 hits, 15 misses per resource type
+	atomic.StoreInt64(&cache.metrics.instanceHits, 85)
+	atomic.StoreInt64(&cache.metrics.instanceMisses, 15)
+	atomic.StoreInt64(&cache.metrics.instancePoolHits, 90)
+	atomic.StoreInt64(&cache.metrics.instancePoolMisses, 10)
+	atomic.StoreInt64(&cache.metrics.sksClusterHits, 95)
+	atomic.StoreInt64(&cache.metrics.sksClusterMisses, 5)
+	atomic.StoreInt64(&cache.metrics.quotaHits, 99)
+	atomic.StoreInt64(&cache.metrics.quotaMisses, 1)
+
+	metrics := cache.GetMetrics()
+
+	// Verify individual hit rates
+	assert.Equal(t, int64(85), metrics.InstanceHits)
+	assert.Equal(t, int64(15), metrics.InstanceMisses)
+	assert.InDelta(t, 0.85, metrics.InstanceHitRate, 0.001) // 85/100 = 0.85
+
+	assert.Equal(t, int64(90), metrics.InstancePoolHits)
+	assert.Equal(t, int64(10), metrics.InstancePoolMisses)
+	assert.InDelta(t, 0.90, metrics.InstancePoolHitRate, 0.001) // 90/100 = 0.90
+
+	assert.Equal(t, int64(95), metrics.SKSClusterHits)
+	assert.Equal(t, int64(5), metrics.SKSClusterMisses)
+	assert.InDelta(t, 0.95, metrics.SKSClusterHitRate, 0.001) // 95/100 = 0.95
+
+	assert.Equal(t, int64(99), metrics.QuotaHits)
+	assert.Equal(t, int64(1), metrics.QuotaMisses)
+	assert.InDelta(t, 0.99, metrics.QuotaHitRate, 0.001) // 99/100 = 0.99
+
+	// Verify overall metrics
+	assert.Equal(t, int64(369), metrics.TotalHits)    // 85+90+95+99
+	assert.Equal(t, int64(31), metrics.TotalMisses)   // 15+10+5+1
+	assert.InDelta(t, 0.9225, metrics.OverallHitRate, 0.001) // 369/400 = 0.9225
+}
+
+// Test GetMetrics with zero operations
+func TestGetMetrics_ZeroOperations(t *testing.T) {
+	cache := newExoscaleCache(nil, false)
+
+	metrics := cache.GetMetrics()
+
+	// All counts should be zero
+	assert.Equal(t, int64(0), metrics.InstanceHits)
+	assert.Equal(t, int64(0), metrics.InstanceMisses)
+	assert.Equal(t, int64(0), metrics.InstancePoolHits)
+	assert.Equal(t, int64(0), metrics.InstancePoolMisses)
+	assert.Equal(t, int64(0), metrics.SKSClusterHits)
+	assert.Equal(t, int64(0), metrics.SKSClusterMisses)
+	assert.Equal(t, int64(0), metrics.QuotaHits)
+	assert.Equal(t, int64(0), metrics.QuotaMisses)
+	assert.Equal(t, int64(0), metrics.TotalHits)
+	assert.Equal(t, int64(0), metrics.TotalMisses)
+
+	// Hit rates should be 0.0 when there are no operations
+	assert.Equal(t, 0.0, metrics.InstanceHitRate)
+	assert.Equal(t, 0.0, metrics.InstancePoolHitRate)
+	assert.Equal(t, 0.0, metrics.SKSClusterHitRate)
+	assert.Equal(t, 0.0, metrics.QuotaHitRate)
+	assert.Equal(t, 0.0, metrics.OverallHitRate)
+}
+
+// Test InvalidateCache clearing all entries
+func TestInvalidateCache_ClearsAllEntries(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	// Populate cache with data
+	cache.instancesCache["inst-1"] = &cachedInstance{
+		data:      &egoscale.Instance{ID: &[]string{"inst-1"}[0]},
+		fetchedAt: time.Now(),
+		ttl:       5 * time.Minute,
+	}
+	cache.instancePoolsCache["pool-1"] = &cachedInstancePool{
+		data:      &egoscale.InstancePool{ID: &[]string{"pool-1"}[0]},
+		fetchedAt: time.Now(),
+		ttl:       5 * time.Minute,
+	}
+	cache.sksClustersCache = []*cachedSKSCluster{
+		{
+			data:      &egoscale.SKSCluster{ID: &[]string{"cluster-1"}[0]},
+			fetchedAt: time.Now(),
+			ttl:       10 * time.Minute,
+		},
+	}
+	cache.quotaCache["instance"] = &cachedQuota{
+		data:      &egoscale.Quota{Resource: &[]string{"instance"}[0]},
+		fetchedAt: time.Now(),
+		ttl:       1 * time.Hour,
+	}
+
+	// Add some metrics
+	atomic.StoreInt64(&cache.metrics.instanceHits, 100)
+	atomic.StoreInt64(&cache.metrics.instanceMisses, 20)
+
+	// Invalidate
+	cache.InvalidateCache()
+
+	// Verify all caches are cleared
+	assert.Equal(t, 0, len(cache.instancesCache), "Instances cache should be empty")
+	assert.Equal(t, 0, len(cache.instancePoolsCache), "Instance pools cache should be empty")
+	assert.Equal(t, 0, len(cache.sksClustersCache), "SKS clusters cache should be empty")
+	assert.Equal(t, 0, len(cache.quotaCache), "Quota cache should be empty")
+
+	// Verify metrics are reset
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.instanceHits))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.instanceMisses))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.instancePoolHits))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.instancePoolMisses))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.sksClusterHits))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.sksClusterMisses))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.quotaHits))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&cache.metrics.quotaMisses))
+}
+
+// Test SetJitterEnabled affecting TTL calculations
+func TestSetJitterEnabled_AffectsTTLCalculations(t *testing.T) {
+	cache := newExoscaleCache(nil, true)
+	assert.True(t, cache.jitterEnabled, "Jitter should start enabled")
+
+	// Disable jitter
+	cache.SetJitterEnabled(false)
+	assert.False(t, cache.jitterEnabled, "Jitter should now be disabled")
+
+	// Re-enable jitter
+	cache.SetJitterEnabled(true)
+	assert.True(t, cache.jitterEnabled, "Jitter should be enabled again")
+}
+
+func TestSetJitterEnabled_ThreadSafe(t *testing.T) {
+	cache := newExoscaleCache(nil, true)
+
+	// Toggle jitter concurrently
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(enabled bool) {
+			defer wg.Done()
+			cache.SetJitterEnabled(enabled)
+		}(i%2 == 0)
+	}
+	wg.Wait()
+
+	// Should complete without data races (verify with -race flag)
+}
+
+// Test instance calls ≤ once per 5min
+func TestAPILoadReduction_InstanceCallsOncePerFiveMinutes(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "instance-ttl-test"
+	expectedInstance := &egoscale.Instance{ID: &testID}
+
+	// API should be called only once despite multiple requests within TTL
+	mockClient.On("GetInstance", mock.Anything, "ch-gva-2", testID).Return(expectedInstance, nil).Once()
+
+	// Simulate 30 requests over a short period (all within 5min TTL)
+	for i := 0; i < 30; i++ {
+		_, err := cache.GetInstance(context.Background(), "ch-gva-2", testID)
+		assert.NoError(t, err)
+	}
+
+	// Verify API was called exactly once
+	mockClient.AssertExpectations(t)
+
+	// Verify cache hit rate is high (29 hits out of 30 total)
+	metrics := cache.GetMetrics()
+	assert.Equal(t, int64(29), metrics.InstanceHits)
+	assert.Equal(t, int64(1), metrics.InstanceMisses)
+	assert.InDelta(t, 0.9667, metrics.InstanceHitRate, 0.001) // 29/30 = 96.67%
+}
+
+// Test pool calls ≤ once per 5min
+func TestAPILoadReduction_PoolCallsOncePerFiveMinutes(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "pool-ttl-test"
+	expectedPool := &egoscale.InstancePool{ID: &testID}
+
+	// API should be called only once
+	mockClient.On("GetInstancePool", mock.Anything, "ch-gva-2", testID).Return(expectedPool, nil).Once()
+
+	// Simulate 20 requests within TTL
+	for i := 0; i < 20; i++ {
+		_, err := cache.GetInstancePool(context.Background(), "ch-gva-2", testID)
+		assert.NoError(t, err)
+	}
+
+	mockClient.AssertExpectations(t)
+
+	metrics := cache.GetMetrics()
+	assert.Equal(t, int64(19), metrics.InstancePoolHits)
+	assert.Equal(t, int64(1), metrics.InstancePoolMisses)
+	assert.InDelta(t, 0.95, metrics.InstancePoolHitRate, 0.001) // 19/20 = 95%
+}
+
+// Test SKS cluster calls ≤ once per 10min
+func TestAPILoadReduction_SKSClusterCallsOncePerTenMinutes(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	expectedClusters := []*egoscale.SKSCluster{
+		{ID: &[]string{"cluster-1"}[0]},
+		{ID: &[]string{"cluster-2"}[0]},
+	}
+
+	// API should be called only once (10min TTL is longer than 5min)
+	mockClient.On("ListSKSClusters", mock.Anything, "ch-gva-2").Return(expectedClusters, nil).Once()
+
+	// Simulate 25 requests within TTL
+	for i := 0; i < 25; i++ {
+		_, err := cache.ListSKSClusters(context.Background(), "ch-gva-2")
+		assert.NoError(t, err)
+	}
+
+	mockClient.AssertExpectations(t)
+
+	metrics := cache.GetMetrics()
+	assert.Equal(t, int64(24), metrics.SKSClusterHits)
+	assert.Equal(t, int64(1), metrics.SKSClusterMisses)
+	assert.InDelta(t, 0.96, metrics.SKSClusterHitRate, 0.001) // 24/25 = 96%
+}
+
+// Test quota calls ≤ once per hour
+func TestAPILoadReduction_QuotaCallsOncePerHour(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	resource := "instance"
+	limit := int64(100)
+	expectedQuota := &egoscale.Quota{Resource: &resource, Limit: &limit}
+
+	// API should be called only once (1hr TTL is very long)
+	mockClient.On("GetQuota", mock.Anything, "ch-gva-2", resource).Return(expectedQuota, nil).Once()
+
+	// Simulate 100 requests within TTL
+	for i := 0; i < 100; i++ {
+		_, err := cache.GetQuota(context.Background(), "ch-gva-2", resource)
+		assert.NoError(t, err)
+	}
+
+	mockClient.AssertExpectations(t)
+
+	metrics := cache.GetMetrics()
+	assert.Equal(t, int64(99), metrics.QuotaHits)
+	assert.Equal(t, int64(1), metrics.QuotaMisses)
+	assert.InDelta(t, 0.99, metrics.QuotaHitRate, 0.001) // 99/100 = 99%
+}
+
+// Integration test verifying 90% API call reduction
+func TestAPILoadReduction_90PercentReduction(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	// Setup test data
+	instanceID := "inst-1"
+	poolID := "pool-1"
+	resource := "instance"
+
+	expectedInstance := &egoscale.Instance{ID: &instanceID}
+	expectedPool := &egoscale.InstancePool{ID: &poolID}
+	expectedClusters := []*egoscale.SKSCluster{{ID: &[]string{"cluster-1"}[0]}}
+	expectedQuota := &egoscale.Quota{Resource: &resource}
+
+	// Each API should be called only once (simulating 10 autoscaler loops within TTL)
+	mockClient.On("GetInstance", mock.Anything, "ch-gva-2", instanceID).Return(expectedInstance, nil).Once()
+	mockClient.On("GetInstancePool", mock.Anything, "ch-gva-2", poolID).Return(expectedPool, nil).Once()
+	mockClient.On("ListSKSClusters", mock.Anything, "ch-gva-2").Return(expectedClusters, nil).Once()
+	mockClient.On("GetQuota", mock.Anything, "ch-gva-2", resource).Return(expectedQuota, nil).Once()
+
+	// Simulate 10 autoscaler loops (each loop makes 4 API calls)
+	// Without caching: 40 API calls
+	// With caching: 4 API calls (one per resource type on first loop)
+	for loop := 0; loop < 10; loop++ {
+		_, _ = cache.GetInstance(context.Background(), "ch-gva-2", instanceID)
+		_, _ = cache.GetInstancePool(context.Background(), "ch-gva-2", poolID)
+		_, _ = cache.ListSKSClusters(context.Background(), "ch-gva-2")
+		_, _ = cache.GetQuota(context.Background(), "ch-gva-2", resource)
+	}
+
+	// Verify each API was called exactly once
+	mockClient.AssertExpectations(t)
+
+	// Verify overall metrics show high hit rate
+	metrics := cache.GetMetrics()
+	// Total operations: 40 (10 loops * 4 resource types)
+	// Total hits: 36 (9 cached loops * 4 resource types)
+	// Total misses: 4 (first loop only)
+	assert.Equal(t, int64(36), metrics.TotalHits)
+	assert.Equal(t, int64(4), metrics.TotalMisses)
+	assert.InDelta(t, 0.90, metrics.OverallHitRate, 0.001) // 36/40 = 90%
+
+	// API call reduction: 90% (4 API calls instead of 40)
+	apiCallsWithoutCache := 40
+	apiCallsWithCache := 4
+	reduction := float64(apiCallsWithoutCache-apiCallsWithCache) / float64(apiCallsWithoutCache)
+	assert.InDelta(t, 0.90, reduction, 0.001) // 90% reduction
+}
+
+// Test jitter spreading cache expiration times
+func TestJitter_SpreadsExpirationTimes(t *testing.T) {
+	// Create 100 instances with jittered TTLs
+	baseTTL := 5 * time.Minute
+	ttls := make([]time.Duration, 100)
+
+	for i := 0; i < 100; i++ {
+		ttl := calculateTTLWithJitter(baseTTL, true)
+		ttls[i] = ttl
+	}
+
+	// Verify TTLs are spread across the jitter range
+	minExpected := baseTTL + time.Duration(float64(baseTTL)*0.10)
+	maxExpected := baseTTL + time.Duration(float64(baseTTL)*0.30)
+
+	for _, ttl := range ttls {
+		assert.GreaterOrEqual(t, ttl, minExpected, "TTL should be at least base + 10%%")
+		assert.LessOrEqual(t, ttl, maxExpected, "TTL should be at most base + 30%%")
+	}
+
+	// Verify TTLs are NOT all the same (distribution exists)
+	allSame := true
+	firstTTL := ttls[0]
+	for _, ttl := range ttls[1:] {
+		if ttl != firstTTL {
+			allSame = false
+			break
+		}
+	}
+	assert.False(t, allSame, "TTLs should be distributed, not all identical")
+}
+
+// Test jitter preventing simultaneous refreshes
+func TestJitter_PreventsSimultaneousRefreshes(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+
+	// Simulate 10 autoscaler instances
+	caches := make([]*exoscaleCache, 10)
+	expirationTimes := make([]time.Time, 10)
+
+	for i := 0; i < 10; i++ {
+		caches[i] = newExoscaleCache(mockClient, true) // Jitter enabled
+		// Store instance in cache
+		caches[i].instancesCache["test-id"] = &cachedInstance{
+			data:      &egoscale.Instance{ID: &[]string{"test-id"}[0]},
+			fetchedAt: time.Now(),
+			ttl:       calculateTTLWithJitter(5*time.Minute, true),
+		}
+		// Calculate expiration time
+		entry := caches[i].instancesCache["test-id"]
+		expirationTimes[i] = entry.fetchedAt.Add(entry.ttl)
+	}
+
+	// Verify expiration times are spread out (not synchronized)
+	for i := 0; i < len(expirationTimes)-1; i++ {
+		for j := i + 1; j < len(expirationTimes); j++ {
+			// Most expiration times should differ (allowing for rare collisions)
+			// With 10-30% jitter on 5min (30-90s range), timestamps should vary
+			diff := expirationTimes[i].Sub(expirationTimes[j]).Abs()
+			// We don't assert all are different (might have rare collisions)
+			// But the overall distribution should prevent thundering herd
+			_ = diff // Log or track distribution
+		}
+	}
+
+	// Statistical check: at least 70% should have unique expiration times
+	uniqueCount := 0
+	for i := 0; i < len(expirationTimes); i++ {
+		isUnique := true
+		for j := 0; j < len(expirationTimes); j++ {
+			if i != j && expirationTimes[i].Equal(expirationTimes[j]) {
+				isUnique = false
+				break
+			}
+		}
+		if isUnique {
+			uniqueCount++
+		}
+	}
+
+	// At least 70% should be unique (allowing for some random collisions)
+	assert.GreaterOrEqual(t, uniqueCount, 7, "At least 70%% of expiration times should be unique")
+}
+
+// Test instances TTL with jitter (5-6.5min range)
+func TestJitter_InstancesTTLRange(t *testing.T) {
+	baseTTL := 5 * time.Minute
+	minExpected := baseTTL + time.Duration(float64(baseTTL)*0.10) // 5.5min
+	maxExpected := baseTTL + time.Duration(float64(baseTTL)*0.30) // 6.5min
+
+	// Test 50 iterations
+	for i := 0; i < 50; i++ {
+		ttl := calculateTTLWithJitter(baseTTL, true)
+		assert.GreaterOrEqual(t, ttl, minExpected, "Instance TTL should be >= 5.5min")
+		assert.LessOrEqual(t, ttl, maxExpected, "Instance TTL should be <= 6.5min")
+	}
+}
+
+// Test pools TTL with jitter (5-6.5min range)
+func TestJitter_PoolsTTLRange(t *testing.T) {
+	baseTTL := 5 * time.Minute
+	minExpected := baseTTL + time.Duration(float64(baseTTL)*0.10) // 5.5min
+	maxExpected := baseTTL + time.Duration(float64(baseTTL)*0.30) // 6.5min
+
+	// Test 50 iterations
+	for i := 0; i < 50; i++ {
+		ttl := calculateTTLWithJitter(baseTTL, true)
+		assert.GreaterOrEqual(t, ttl, minExpected, "Pool TTL should be >= 5.5min")
+		assert.LessOrEqual(t, ttl, maxExpected, "Pool TTL should be <= 6.5min")
+	}
+}
+
+// Test SKS clusters TTL with jitter (10-13min range)
+func TestJitter_SKSClustersTTLRange(t *testing.T) {
+	baseTTL := 10 * time.Minute
+	minExpected := baseTTL + time.Duration(float64(baseTTL)*0.10) // 11min
+	maxExpected := baseTTL + time.Duration(float64(baseTTL)*0.30) // 13min
+
+	// Test 50 iterations
+	for i := 0; i < 50; i++ {
+		ttl := calculateTTLWithJitter(baseTTL, true)
+		assert.GreaterOrEqual(t, ttl, minExpected, "SKS cluster TTL should be >= 11min")
+		assert.LessOrEqual(t, ttl, maxExpected, "SKS cluster TTL should be <= 13min")
+	}
+}
+
+// Test quota TTL with jitter (60-78min range)
+func TestJitter_QuotaTTLRange(t *testing.T) {
+	baseTTL := 1 * time.Hour
+	minExpected := baseTTL + time.Duration(float64(baseTTL)*0.10) // 66min
+	maxExpected := baseTTL + time.Duration(float64(baseTTL)*0.30) // 78min
+
+	// Test 50 iterations
+	for i := 0; i < 50; i++ {
+		ttl := calculateTTLWithJitter(baseTTL, true)
+		assert.GreaterOrEqual(t, ttl, minExpected, "Quota TTL should be >= 66min")
+		assert.LessOrEqual(t, ttl, maxExpected, "Quota TTL should be <= 78min")
+	}
+}
+
+// Integration test for multiple loops showing random refresh timing
+func TestJitter_MultipleLoopsRandomRefreshTiming(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, true) // Jitter enabled
+
+	testID := "jitter-test-id"
+	expectedInstance := &egoscale.Instance{ID: &testID}
+
+	// Track when cache entries are created
+	refreshTimestamps := make([]time.Time, 0)
+
+	// Mock API to track calls
+	callCount := 0
+	mockClient.On("GetInstance", mock.Anything, "ch-gva-2", testID).Run(func(args mock.Arguments) {
+		callCount++
+		refreshTimestamps = append(refreshTimestamps, time.Now())
+	}).Return(expectedInstance, nil)
+
+	// First call - populate cache
+	_, err := cache.GetInstance(context.Background(), "ch-gva-2", testID)
+	assert.NoError(t, err)
+
+	// Get the TTL that was assigned
+	entry := cache.instancesCache[testID]
+	firstTTL := entry.ttl
+
+	// Create 5 more caches with same ID - each will get different TTL due to jitter
+	ttls := []time.Duration{firstTTL}
+	for i := 0; i < 5; i++ {
+		freshCache := newExoscaleCache(mockClient, true)
+		_, _ = freshCache.GetInstance(context.Background(), "ch-gva-2", testID)
+		ttls = append(ttls, freshCache.instancesCache[testID].ttl)
+	}
+
+	// Verify TTLs are different across caches (jitter creates variation)
+	uniqueTTLs := make(map[time.Duration]bool)
+	for _, ttl := range ttls {
+		uniqueTTLs[ttl] = true
+	}
+
+	// With jitter, we should see multiple unique TTL values (not all identical)
+	assert.Greater(t, len(uniqueTTLs), 1, "Jitter should create variation in TTLs")
+
+	// Verify all TTLs are within expected range
+	baseTTL := 5 * time.Minute
+	minExpected := baseTTL + time.Duration(float64(baseTTL)*0.10)
+	maxExpected := baseTTL + time.Duration(float64(baseTTL)*0.30)
+
+	for _, ttl := range ttls {
+		assert.GreaterOrEqual(t, ttl, minExpected)
+		assert.LessOrEqual(t, ttl, maxExpected)
+	}
+}
+
+// Test concurrent reads (100 goroutines, same ID)
+func TestThreadSafety_ConcurrentReadsSameID(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "concurrent-test-id"
+	// Pre-populate cache
+	cache.instancesCache[testID] = &cachedInstance{
+		data:      &egoscale.Instance{ID: &testID, Name: &[]string{"test-instance"}[0]},
+		fetchedAt: time.Now(),
+		ttl:       5 * time.Minute,
+	}
+
+	// 100 concurrent reads of the same ID
+	var wg sync.WaitGroup
+	errors := make(chan error, 100)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			instance, err := cache.GetInstance(context.Background(), "ch-gva-2", testID)
+			if err != nil {
+				errors <- err
+				return
+			}
+			if instance == nil || *instance.ID != testID {
+				errors <- assert.AnError
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+
+	// No errors should occur
+	for err := range errors {
+		t.Errorf("Concurrent read error: %v", err)
+	}
+
+	// All reads should hit cache (no API calls)
+	mockClient.AssertNotCalled(t, "GetInstance")
+
+	// Verify metrics (all 100 should be hits)
+	assert.Equal(t, int64(100), atomic.LoadInt64(&cache.metrics.instanceHits))
+}
+
+// Test concurrent reads (different IDs)
+func TestThreadSafety_ConcurrentReadsDifferentIDs(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	// Pre-populate cache with 10 different instances
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("instance-%d", i)
+		cache.instancesCache[id] = &cachedInstance{
+			data:      &egoscale.Instance{ID: &id},
+			fetchedAt: time.Now(),
+			ttl:       5 * time.Minute,
+		}
+	}
+
+	// 100 concurrent reads across different IDs
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			id := fmt.Sprintf("instance-%d", index%10)
+			_, _ = cache.GetInstance(context.Background(), "ch-gva-2", id)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Should complete without panics or deadlocks (run with -race to verify)
+	mockClient.AssertNotCalled(t, "GetInstance")
+}
+
+// Test concurrent writes (race detector)
+func TestThreadSafety_ConcurrentWrites(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	// Mock API calls for 10 different instances
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("write-test-%d", i)
+		mockClient.On("GetInstance", mock.Anything, "ch-gva-2", id).
+			Return(&egoscale.Instance{ID: &id}, nil)
+	}
+
+	// 100 concurrent writes (cache misses that populate cache)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			id := fmt.Sprintf("write-test-%d", index%10)
+			_, _ = cache.GetInstance(context.Background(), "ch-gva-2", id)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Should complete without data races (run with `go test -race`)
+	// Verify cache was populated
+	assert.Equal(t, 10, len(cache.instancesCache))
+}
+
+// Test read during write
+func TestThreadSafety_ReadDuringWrite(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "read-write-test"
+	mockClient.On("GetInstance", mock.Anything, "ch-gva-2", testID).
+		Return(&egoscale.Instance{ID: &testID}, nil).
+		Run(func(args mock.Arguments) {
+			// Simulate slow API call
+			time.Sleep(10 * time.Millisecond)
+		})
+
+	// Start a write (cache miss)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = cache.GetInstance(context.Background(), "ch-gva-2", testID)
+	}()
+
+	// Give write time to start
+	time.Sleep(2 * time.Millisecond)
+
+	// Start concurrent reads while write is in progress
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = cache.GetInstance(context.Background(), "ch-gva-2", testID)
+		}()
+	}
+
+	wg.Wait()
+
+	// Should complete without deadlock
+	// One of the goroutines should have written to cache
+	assert.NotNil(t, cache.instancesCache[testID])
+}
+
+// Test atomic metrics updates under concurrency
+func TestThreadSafety_AtomicMetricsUpdates(t *testing.T) {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+
+	testID := "metrics-concurrent-test"
+	cache.instancesCache[testID] = &cachedInstance{
+		data:      &egoscale.Instance{ID: &testID},
+		fetchedAt: time.Now(),
+		ttl:       5 * time.Minute,
+	}
+
+	// 1000 concurrent cache hits
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = cache.GetInstance(context.Background(), "ch-gva-2", testID)
+		}()
+	}
+
+	wg.Wait()
+
+	// Metrics should be exactly 1000 (atomic operations prevent lost updates)
+	metrics := cache.GetMetrics()
+	assert.Equal(t, int64(1000), metrics.InstanceHits)
+	assert.Equal(t, int64(0), metrics.InstanceMisses)
+}

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider_test.go
@@ -78,21 +78,33 @@ func (m *exoscaleClientMock) EvictSKSNodepoolMembers(
 
 func (m *exoscaleClientMock) GetInstance(ctx context.Context, zone, id string) (*egoscale.Instance, error) {
 	args := m.Called(ctx, zone, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*egoscale.Instance), args.Error(1)
 }
 
 func (m *exoscaleClientMock) GetInstancePool(ctx context.Context, zone, id string) (*egoscale.InstancePool, error) {
 	args := m.Called(ctx, zone, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*egoscale.InstancePool), args.Error(1)
 }
 
 func (m *exoscaleClientMock) GetQuota(ctx context.Context, zone string, resource string) (*egoscale.Quota, error) {
 	args := m.Called(ctx, zone, resource)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*egoscale.Quota), args.Error(1)
 }
 
 func (m *exoscaleClientMock) ListSKSClusters(ctx context.Context, zone string) ([]*egoscale.SKSCluster, error) {
 	args := m.Called(ctx, zone)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).([]*egoscale.SKSCluster), args.Error(1)
 }
 
@@ -430,6 +442,249 @@ func (ts *cloudProviderTestSuite) TestExoscaleCloudProvider_NodeGroups() {
 	// ---------------------------------------------------------------
 
 	ts.Require().Len(ts.p.NodeGroups(), 2)
+}
+
+// TestCache_NodeGroupForNode_CachesSKSClusters verifies that NodeGroupForNode uses cached SKS clusters
+func (ts *cloudProviderTestSuite) TestCache_NodeGroupForNode_CachesSKSClusters() {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false) // Disable jitter for deterministic testing
+	ts.p.manager.client = cache
+
+	// Mock ListSKSClusters - should only be called once due to caching
+	mockClient.On("ListSKSClusters", ts.p.manager.ctx, ts.p.manager.zone).
+		Return(
+			[]*egoscale.SKSCluster{{
+				ID:   &testSKSClusterID,
+				Name: &testSKSClusterName,
+				Nodepools: []*egoscale.SKSNodepool{{
+					ID:             &testSKSNodepoolID,
+					InstancePoolID: &testInstancePoolID,
+					Name:           &testSKSNodepoolName,
+				}},
+			}},
+			nil,
+		).Once()
+
+	mockClient.On("GetQuota", ts.p.manager.ctx, ts.p.manager.zone, testComputeInstanceQuotaName).
+		Return(
+			&egoscale.Quota{
+				Resource: &testComputeInstanceQuotaName,
+				Usage:    &testComputeInstanceQuotaUsage,
+				Limit:    &testComputeInstanceQuotaLimit,
+			},
+			nil,
+		).Once()
+
+	mockClient.On("GetInstancePool", ts.p.manager.ctx, ts.p.manager.zone, testInstancePoolID).
+		Return(
+			&egoscale.InstancePool{
+				ID: &testInstancePoolID,
+				Manager: &egoscale.InstancePoolManager{
+					ID:   testSKSNodepoolID,
+					Type: "sks-nodepool",
+				},
+				Name: &testInstancePoolName,
+			},
+			nil,
+		).Once()
+
+	mockClient.On("GetInstance", ts.p.manager.ctx, ts.p.manager.zone, testInstanceID).
+		Return(
+			&egoscale.Instance{
+				ID:   &testInstanceID,
+				Name: &testInstanceName,
+				Manager: &egoscale.InstanceManager{
+					ID:   testInstancePoolID,
+					Type: "instance-pool",
+				},
+			},
+			nil,
+		).Once()
+
+	// First call - populates cache
+	nodeGroup1, err := ts.p.NodeGroupForNode(&apiv1.Node{
+		Spec: apiv1.NodeSpec{
+			ProviderID: toProviderID(testInstanceID),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string{
+				"topology.kubernetes.io/region": testZone,
+			},
+		},
+	})
+	ts.Require().NoError(err)
+	ts.Require().NotNil(nodeGroup1)
+
+	// Second call within TTL - uses cache, no additional API calls
+	nodeGroup2, err := ts.p.NodeGroupForNode(&apiv1.Node{
+		Spec: apiv1.NodeSpec{
+			ProviderID: toProviderID(testInstanceID),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string{
+				"topology.kubernetes.io/region": testZone,
+			},
+		},
+	})
+	ts.Require().NoError(err)
+	ts.Require().NotNil(nodeGroup2)
+
+	// Verify all mocks were called exactly the expected number of times
+	mockClient.AssertExpectations(ts.T())
+}
+
+// TestCache_Nodes_UsesCachedInstances verifies that Nodes() uses cached instances
+func (ts *cloudProviderTestSuite) TestCache_Nodes_UsesCachedInstances() {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+	ts.p.manager.client = cache
+
+	// Create an instance pool node group
+	instanceIDs := []string{testInstanceID}
+	ng := &instancePoolNodeGroup{
+		m: ts.p.manager,
+		instancePool: &egoscale.InstancePool{
+			ID:          &testInstancePoolID,
+			Name:        &testInstancePoolName,
+			InstanceIDs: &instanceIDs,
+		},
+	}
+
+	// Mock GetInstance - should only be called once due to caching
+	mockClient.On("GetInstance", ts.p.manager.ctx, ts.p.manager.zone, testInstanceID).
+		Return(
+			&egoscale.Instance{
+				ID:    &testInstanceID,
+				Name:  &testInstanceName,
+				State: &testInstanceState,
+			},
+			nil,
+		).Once()
+
+	// First call - cache miss
+	nodes1, err := ng.Nodes()
+	ts.Require().NoError(err)
+	ts.Require().Len(nodes1, 1)
+
+	// Second call within TTL - cache hit
+	nodes2, err := ng.Nodes()
+	ts.Require().NoError(err)
+	ts.Require().Len(nodes2, 1)
+
+	// Verify GetInstance was only called once
+	mockClient.AssertExpectations(ts.T())
+}
+
+// TestCache_Refresh_BenefitsFromCache verifies that Refresh() benefits from cached pools
+func (ts *cloudProviderTestSuite) TestCache_Refresh_BenefitsFromCache() {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+	ts.p.manager.client = cache
+
+	// Add a node group to the manager
+	ts.p.manager.nodeGroups = []cloudprovider.NodeGroup{
+		&instancePoolNodeGroup{
+			m: ts.p.manager,
+			instancePool: &egoscale.InstancePool{
+				ID:   &testInstancePoolID,
+				Name: &testInstancePoolName,
+			},
+		},
+	}
+
+	// Mock GetInstancePool - should only be called once due to caching
+	mockClient.On("GetInstancePool", ts.p.manager.ctx, ts.p.manager.zone, testInstancePoolID).
+		Return(
+			&egoscale.InstancePool{
+				ID:   &testInstancePoolID,
+				Name: &testInstancePoolName,
+			},
+			nil,
+		).Once()
+
+	// First refresh - cache miss
+	err := ts.p.manager.Refresh()
+	ts.Require().NoError(err)
+	ts.Require().Len(ts.p.manager.nodeGroups, 1)
+
+	// Second refresh within TTL - cache hit, no API call
+	err = ts.p.manager.Refresh()
+	ts.Require().NoError(err)
+	ts.Require().Len(ts.p.manager.nodeGroups, 1)
+
+	// Verify GetInstancePool was only called once
+	mockClient.AssertExpectations(ts.T())
+}
+
+// TestCache_ConsecutiveLoops_ZeroAPICalls verifies consecutive autoscaler loops use only cache
+func (ts *cloudProviderTestSuite) TestCache_ConsecutiveLoops_ZeroAPICalls() {
+	mockClient := new(exoscaleClientMock)
+	cache := newExoscaleCache(mockClient, false)
+	ts.p.manager.client = cache
+
+	// Setup: Add node groups to manager
+	instanceIDs := []string{testInstanceID}
+	ts.p.manager.nodeGroups = []cloudprovider.NodeGroup{
+		&instancePoolNodeGroup{
+			m: ts.p.manager,
+			instancePool: &egoscale.InstancePool{
+				ID:          &testInstancePoolID,
+				Name:        &testInstancePoolName,
+				InstanceIDs: &instanceIDs,
+			},
+		},
+	}
+
+	// Mock API calls - each should only be called ONCE in first loop
+	poolInstanceIDs := []string{testInstanceID}
+	mockClient.On("GetInstancePool", ts.p.manager.ctx, ts.p.manager.zone, testInstancePoolID).
+		Return(
+			&egoscale.InstancePool{
+				ID:          &testInstancePoolID,
+				Name:        &testInstancePoolName,
+				InstanceIDs: &poolInstanceIDs,
+			},
+			nil,
+		).Once()
+
+	mockClient.On("GetInstance", ts.p.manager.ctx, ts.p.manager.zone, testInstanceID).
+		Return(
+			&egoscale.Instance{
+				ID:    &testInstanceID,
+				Name:  &testInstanceName,
+				State: &testInstanceState,
+			},
+			nil,
+		).Once()
+
+	// Simulate autoscaler loop 1: Refresh + Nodes
+	err := ts.p.manager.Refresh()
+	ts.Require().NoError(err)
+
+	ng := ts.p.manager.nodeGroups[0].(*instancePoolNodeGroup)
+	nodes1, err := ng.Nodes()
+	ts.Require().NoError(err)
+	ts.Require().Len(nodes1, 1)
+
+	// Simulate autoscaler loop 2: Refresh + Nodes (within TTL - cache hits)
+	err = ts.p.manager.Refresh()
+	ts.Require().NoError(err)
+
+	nodes2, err := ng.Nodes()
+	ts.Require().NoError(err)
+	ts.Require().Len(nodes2, 1)
+
+	// Simulate autoscaler loop 3: Refresh + Nodes (within TTL - cache hits)
+	err = ts.p.manager.Refresh()
+	ts.Require().NoError(err)
+
+	nodes3, err := ng.Nodes()
+	ts.Require().NoError(err)
+	ts.Require().Len(nodes3, 1)
+
+	// Verify API calls only happened once (first loop)
+	// Subsequent loops used cache exclusively
+	mockClient.AssertExpectations(ts.T())
 }
 
 func TestSuiteExoscaleCloudProvider(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_manager.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_manager.go
@@ -80,11 +80,21 @@ func newManager(discoveryOpts cloudprovider.NodeGroupDiscoveryOptions) (*Manager
 		return nil, err
 	}
 
-	debugf("initializing manager with zone=%s environment=%s", zone, apiEnvironment)
+	// Check if caching should be enabled (default: true)
+	var wrappedClient exoscaleClient
+	cachingEnabled := os.Getenv("EXOSCALE_API_CACHE_ENABLED")
+	if cachingEnabled == "" || cachingEnabled == "true" || cachingEnabled == "1" {
+		// Wrap client with caching layer (jitter enabled by default)
+		wrappedClient = newExoscaleCache(client, true)
+		debugf("initializing manager with zone=%s environment=%s (caching enabled)", zone, apiEnvironment)
+	} else {
+		wrappedClient = client
+		debugf("initializing manager with zone=%s environment=%s (caching disabled)", zone, apiEnvironment)
+	}
 
 	m := &Manager{
 		ctx:           exoapi.WithEndpoint(context.Background(), exoapi.NewReqEndpoint(apiEnvironment, zone)),
-		client:        client,
+		client:        wrappedClient,
 		zone:          zone,
 		discoveryOpts: discoveryOpts,
 	}

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_manager_test.go
@@ -52,3 +52,101 @@ func (ts *cloudProviderTestSuite) TestComputeInstanceQuota() {
 	ts.Require().NoError(err)
 	ts.Require().Equal(int(testComputeInstanceQuotaLimit), actual)
 }
+
+// TestManager_UsesCachedClient verifies that the Manager's client is wrapped with cache
+func (ts *cloudProviderTestSuite) TestManager_UsesCachedClient() {
+	// The manager is already created in SetupTest with cache wrapping
+	// We verify by checking that the cache layer intercepts calls
+
+	// Create a new manager without mocking to verify cache wrapping
+	manager, err := newManager(cloudprovider.NodeGroupDiscoveryOptions{})
+	ts.Require().NoError(err)
+	ts.Require().NotNil(manager)
+
+	// The client should be an exoscaleCache, not the raw egoscale client
+	// We can verify by checking if it implements the exoscaleClient interface
+	_, ok := manager.client.(exoscaleClient)
+	ts.Require().True(ok, "manager client should implement exoscaleClient interface")
+}
+
+// TestManager_CacheReducesAPICalls verifies that the cache reduces API call count
+func (ts *cloudProviderTestSuite) TestManager_CacheReducesAPICalls() {
+	mockClient := new(exoscaleClientMock)
+
+	// Create a cache wrapping the mock client
+	cache := newExoscaleCache(mockClient, false) // Disable jitter for deterministic testing
+
+	// Replace the manager's client with our cached mock
+	ts.p.manager.client = cache
+
+	// Mock a successful GetInstancePool call (should only be called once)
+	mockClient.On("GetInstancePool", ts.p.manager.ctx, ts.p.manager.zone, testInstancePoolID).
+		Return(
+			&egoscale.InstancePool{
+				ID:   &testInstancePoolID,
+				Name: &testInstancePoolName,
+				Size: &testInstancePoolSize,
+			},
+			nil,
+		).Once() // Critical: Should only be called once
+
+	// First call - cache miss, API called
+	pool1, err := ts.p.manager.client.GetInstancePool(ts.p.manager.ctx, ts.p.manager.zone, testInstancePoolID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(testInstancePoolID, *pool1.ID)
+
+	// Second call within TTL - cache hit, no API call
+	pool2, err := ts.p.manager.client.GetInstancePool(ts.p.manager.ctx, ts.p.manager.zone, testInstancePoolID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(testInstancePoolID, *pool2.ID)
+
+	// Third call within TTL - cache hit, no API call
+	pool3, err := ts.p.manager.client.GetInstancePool(ts.p.manager.ctx, ts.p.manager.zone, testInstancePoolID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(testInstancePoolID, *pool3.ID)
+
+	// Verify mock was called exactly once (cache prevented additional calls)
+	mockClient.AssertExpectations(ts.T())
+}
+
+// TestManager_CachingEnabledByDefault verifies that caching is enabled by default
+func (ts *cloudProviderTestSuite) TestManager_CachingEnabledByDefault() {
+	// Unset the env var to test default behavior
+	os.Unsetenv("EXOSCALE_API_CACHE_ENABLED")
+
+	manager, err := newManager(cloudprovider.NodeGroupDiscoveryOptions{})
+	ts.Require().NoError(err)
+	ts.Require().NotNil(manager)
+
+	// Client should be wrapped with cache (exoscaleCache type)
+	_, ok := manager.client.(*exoscaleCache)
+	ts.Require().True(ok, "manager client should be wrapped with cache by default")
+}
+
+// TestManager_CachingCanBeDisabled verifies that caching can be explicitly disabled
+func (ts *cloudProviderTestSuite) TestManager_CachingCanBeDisabled() {
+	// Explicitly disable caching
+	ts.T().Setenv("EXOSCALE_API_CACHE_ENABLED", "false")
+
+	manager, err := newManager(cloudprovider.NodeGroupDiscoveryOptions{})
+	ts.Require().NoError(err)
+	ts.Require().NotNil(manager)
+
+	// Client should NOT be wrapped with cache
+	_, ok := manager.client.(*exoscaleCache)
+	ts.Require().False(ok, "manager client should not be wrapped when caching is disabled")
+}
+
+// TestManager_CachingExplicitlyEnabled verifies that caching can be explicitly enabled
+func (ts *cloudProviderTestSuite) TestManager_CachingExplicitlyEnabled() {
+	// Explicitly enable caching
+	ts.T().Setenv("EXOSCALE_API_CACHE_ENABLED", "true")
+
+	manager, err := newManager(cloudprovider.NodeGroupDiscoveryOptions{})
+	ts.Require().NoError(err)
+	ts.Require().NotNil(manager)
+
+	// Client should be wrapped with cache
+	_, ok := manager.client.(*exoscaleCache)
+	ts.Require().True(ok, "manager client should be wrapped when caching is explicitly enabled")
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This implements caching for the Exoscale cloudprovider. Exoscale API calls are now cached, which
reduces the reaction time of the controller
and speeds up scaleUps by a lot, especially for larger clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/autoscaler/issues/7543

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
